### PR TITLE
Homepage - remove webpack files from RecipeFileTree

### DIFF
--- a/src/Model/RecipeFileTree.php
+++ b/src/Model/RecipeFileTree.php
@@ -26,8 +26,6 @@ class RecipeFileTree
             ->addFile('assets/controllers/hello_controller.js', 'An example controller. Add it to any element with <code class="text-nowrap">data-controller="hello"</code>')
             ->addDirectory('assets/styles')
             ->addFile('assets/styles/app.css', 'Your main CSS file')
-            ->addFile('package.json', 'Holds your node dependencies, most importantly Stimulus & Webpack Encore.')
-            ->addFile('webpack.config.js', 'Configuration file for Webpack Encore: the tool that processes and combines all of your CSS and JS files.')
         ;
     }
 

--- a/tests/Unit/Model/RecipeFileTreeTest.php
+++ b/tests/Unit/Model/RecipeFileTreeTest.php
@@ -28,9 +28,5 @@ class RecipeFileTreeTest extends TestCase
         $this->assertSame('bootstrap.js', $files['assets']['files']['assets/bootstrap.js']['filename']);
         $this->assertArrayHasKey('assets/controllers', $files['assets']['files']);
         $this->assertArrayNotHasKey('assets/controllers/hello_controller.js', $files['assets']['files']);
-
-        $this->assertArrayHasKey('package.json', $files);
-        $this->assertFalse($files['package.json']['isDirectory']);
-        $this->assertSame('package.json', $files['package.json']['filename']);
     }
 }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Hey Sf UX Team,

I just updated the RecipeFileTree which no need `package.json` or `webpack.config.js` using asset-mapper.
