### PR TITLE
[Theme] Sync dark theme preference with local storage at first visit

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,6 +23,7 @@
             <script>
               const theme = localStorage.getItem('user-theme') || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
               document.documentElement.setAttribute('data-bs-theme', theme === 'light' ? 'light' : 'dark');
+              localStorage.setItem('user-theme', theme === 'light' ? 'light' : 'dark');
             </script>
             {% block importmap %}
                 <script>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | yes
| New feature?   | no
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Forgotten in https://github.com/symfony/ux.symfony.com/commit/edd15a54cc3b3bcbd0e7f268e8cfec7dd21f2b30.

When a visitor visit the site for the first time, `const theme = localStorage.getItem('user-theme') || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');` can gives `dark` if `user-theme` is not present in the local storage and is matching the user's dark color scheme.
But the Toolkit `<iframe>` previews needs to have access to `user-theme` key from local storage, without this fix, the site can be dark but the Toolkit preview light.
