### PR TITLE
[Typed] Deprecate the component

### DIFF
--- a/src/Controller/UxPackagesController.php
+++ b/src/Controller/UxPackagesController.php
@@ -22,10 +22,12 @@ class UxPackagesController extends AbstractController
     #[Route('/packages', name: 'app_packages')]
     public function __invoke(UxPackageRepository $packageRepository): Response
     {
-        $packages = $packageRepository->findAll();
+        $packages = $packageRepository->findAll(deprecated: false);
+        $deprecatedPackages = $packageRepository->findAll(deprecated: true);
 
         return $this->render('main/packages.html.twig', [
             'packages' => $packages,
+            'deprecated_packages' => $deprecatedPackages,
         ]);
     }
 

--- a/src/Model/UxPackage.php
+++ b/src/Model/UxPackage.php
@@ -31,6 +31,7 @@ class UxPackage
         private ?string $composerName = null,
         private bool $isDevDependency = false,
         private bool $showDocsLink = true,
+        private bool $isDeprecated = false,
     ) {
     }
 
@@ -156,5 +157,10 @@ class UxPackage
     public function getImage(?string $format = null): string
     {
         return 'images/ux_packages/'.$this->getImageFilename($format);
+    }
+
+    public function isDeprecated(): bool
+    {
+        return $this->isDeprecated;
     }
 }

--- a/src/Service/UxPackageRepository.php
+++ b/src/Service/UxPackageRepository.php
@@ -18,7 +18,7 @@ class UxPackageRepository
     /**
      * @return array<UxPackage>
      */
-    public function findAll(?string $query = null): array
+    public function findAll(?string $query = null, ?bool $deprecated = null): array
     {
         $packages = [
             new UxPackage(
@@ -254,17 +254,20 @@ class UxPackageRepository
                 'linear-gradient(95deg, #20A091 -5%, #4EC9B3 105%)',
                 'Animated Typing with Typed.js',
                 'Animated typing with Typed.js',
+                isDeprecated: true
             ))
                 ->setDocsLink('https://github.com/mattboldt/typed.js/', 'Typed.js documentation'),
         ];
 
-        if (!$query) {
-            return $packages;
+        if ($query) {
+            $packages = array_filter($packages, static fn (UxPackage $package) => str_contains($package->getName(), $query) || str_contains($package->getHumanName(), $query));
         }
 
-        return array_filter($packages, function (UxPackage $package) use ($query) {
-            return str_contains($package->getName(), $query) || str_contains($package->getHumanName(), $query);
-        });
+        if (null !== $deprecated) {
+            $packages = array_filter($packages, static fn (UxPackage $package) => $package->isDeprecated() === $deprecated);
+        }
+
+        return $packages;
     }
 
     public function find(string $name): UxPackage

--- a/templates/components/Package/PackageHeader.html.twig
+++ b/templates/components/Package/PackageHeader.html.twig
@@ -12,6 +12,17 @@
             </p>
         </div>
 
+        {% if package.isDeprecated %}
+            <div class="d-flex justify-content-center">
+                <div class="alert alert-warning my-2" role="alert">
+                    <twig:ux:icon name="bi:exclamation-triangle" class="flex-shrink-0 me-1" width="1em" height="1em" />
+                    {% block deprecated_content %}
+                        This component is <strong>deprecated</strong> and will not receive further updates.<br>
+                    {% endblock %}
+                </div>
+            </div>
+        {% endif %}
+
         <div class="d-flex justify-content-center flex-column-reverse flex-md-row">
             {% if command is not defined or command %}
                 <twig:TerminalCommand

--- a/templates/main/packages.html.twig
+++ b/templates/main/packages.html.twig
@@ -23,6 +23,16 @@
         </div>
     {% endblock %}
 </div>
+
+<h2 class="text-center mt-5">Deprecated packages</h2>
+<p class="text-center mt-2 mb-5">Packages that are still available but will be removed in future versions</p>
+<div class="container-fluid container-xxl px-4 pt-4 px-md-5">
+        <div style="display: grid; gap: 3rem; grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));">
+            {% for package in deprecated_packages %}
+                <twig:Package:PackageBox package="{{ package }}" titleTag="h2" />
+            {% endfor %}
+        </div>
+</div>
 {% endblock %}
 
 {% block aside %}

--- a/templates/ux_packages/typed.html.twig
+++ b/templates/ux_packages/typed.html.twig
@@ -5,12 +5,18 @@
         package: 'typed',
         eyebrowText: 'A Library that Types',
     } %}
+
         {% block title_header %}
             Typed brings text <em>to life</em>
         {% endblock %}
 
         {% block sub_content %}
             Spice up some text by typing, backspacing and re-typing with <a class="font-white text-underline" href="https://github.com/mattboldt/typed.js/" rel="noopener nofollow noreferrer">Typed.js</a>.
+        {% endblock %}
+
+        {% block deprecated_content %}
+            This component is <strong>deprecated</strong> and will not receive further updates.<br>
+            Please follow <a href="https://github.com/symfony/ux/tree/2.x/src/Typed" class="link">the migration steps</a> if you want to keep using Typed in your app.
         {% endblock %}
     {% endcomponent %}
 {% endblock %}

--- a/tests/Functional/UxPackagesTest.php
+++ b/tests/Functional/UxPackagesTest.php
@@ -59,6 +59,12 @@ class UxPackagesTest extends KernelTestCase
                 continue;
             }
 
+            if ($package->isDeprecated()) {
+                // Deprecated packages have a minimal layout
+                yield $package->getName() => [$package, 'This component is deprecated'];
+                continue;
+            }
+
             yield $package->getName() => [$package, \sprintf('%s Doc', $package->getHumanName())];
         }
     }


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Issues         | Part of #16 
| License        | MIT

Show the depreciation of `Typed` component on website
Few other packages will follow, but this first PR is focused on one to validate the changes made on the site 

In comparison with original PR on UX main repo, I choose to not remove example from site. I believe they are still relevant to give a preview of the feature, even if the package is deprecated.
But installation instructions and link to docs are removed

What do you think about it ? 