### PR TITLE
Add margin to Wysiwyg_Tabs when followed by a paragraph

### DIFF
--- a/assets/styles/components/_Wysiwyg_Tabs.scss
+++ b/assets/styles/components/_Wysiwyg_Tabs.scss
@@ -1,6 +1,10 @@
 .Wysiwyg_Tabs {
 }
 
+.Wysiwyg_Tabs:has(+ p) {
+  margin-bottom: 1rem;
+}
+
 .Wysiwyg_TabHead {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Occasionally, you might find both a short description of the example (which is the case for some examples, but not all) and a comment below the wysiwyg block for that example.

Therefore, I added a margin below the wysiwyg block when a paragraph is present.
