### PR TITLE
[Changelog] Add markdown version

### DIFF
--- a/src/Controller/ChangelogController.php
+++ b/src/Controller/ChangelogController.php
@@ -23,13 +23,19 @@ class ChangelogController extends AbstractController
     ) {
     }
 
-    #[Route('/changelog', name: 'app_changelog')]
-    public function __invoke(): Response
+    #[Route('/changelog', name: 'app_changelog', defaults: ['_format' => 'html'])]
+    #[Route('/changelog.md', name: 'app_changelog_md', defaults: ['_format' => 'md'])]
+    public function __invoke(string $_format): Response
     {
         $changelog = $this->changeLogProvider->getChangelog();
 
-        return $this->render('changelog.html.twig', [
+        $response = new Response();
+        if ('md' === $_format) {
+            $response->headers->set('Content-Type', 'text/markdown');
+        }
+
+        return $this->render('changelog.'.$_format.'.twig', [
             'changelog' => $changelog,
-        ]);
+        ], $response);
     }
 }

--- a/templates/changelog.md.twig
+++ b/templates/changelog.md.twig
@@ -1,0 +1,11 @@
+# Changelog
+
+New features, bug fixes, performances and security improvements.
+
+{% for entry in changelog %}
+## {{ entry.name }} ({{ entry.version }} - {{ entry.date|date('Y-m-d') }})
+
+{% for line in entry.body|split('\n') %}
+{% if line|u.startsWith('#') %}#{% endif %}{{ line|raw }}
+{% endfor %}
+{% endfor %}

--- a/tests/Functional/ChangelogTest.php
+++ b/tests/Functional/ChangelogTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Browser\Test\HasBrowser;
+
+class ChangelogTest extends KernelTestCase
+{
+    use HasBrowser;
+
+    public function testChangelogIsAccessible()
+    {
+        $this->browser()
+            ->visit('/changelog')
+            ->assertSuccessful()
+            ->assertHtml()
+            ->assertSeeIn('h1', 'Changelog')
+        ;
+
+        $browser = $this->browser()
+            ->visit('/changelog.md')
+            ->assertSuccessful()
+            ->assertContentType('markdown')
+        ;
+
+        self::assertStringContainsString('# Changelog', $browser->content());
+    }
+}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | yes
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

https://ux.symfony.com/changelog.md now display the changelog in markdown format