### PR TITLE
[Toolkit][Alert] Display class as code in alert example

### DIFF
--- a/templates/toolkit/docs/shadcn/alert.md.twig
+++ b/templates/toolkit/docs/shadcn/alert.md.twig
@@ -29,7 +29,7 @@ Use `Alert:Action` to add a button or other action element to the alert.
 
 ### Custom Colors
 
-You can customize the alert colors by adding custom classes such as bg-amber-50 dark:bg-amber-950 to the `Alert` component.
+You can customize the alert colors by adding custom classes such as `bg-amber-50 dark:bg-amber-950` to the `Alert` component.
 
 {{ toolkit_code_example(kit_id.value, component.name, 'Custom Colors') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Bug fix?       | no
| New feature?   | no
| Issues         | 
| License        | MIT

A suggestion to highligt classes names as code in Alert doc 

<img width="1914" height="186" alt="image" src="https://github.com/user-attachments/assets/11a97be2-76ed-4407-92bd-62e5e0d26bf1" />
