### PR TITLE
[Toolkit][Shadcn] Add docs page for radio-group

### DIFF
--- a/templates/toolkit/docs/shadcn/radio-group.md.twig
+++ b/templates/toolkit/docs/shadcn/radio-group.md.twig
@@ -1,0 +1,35 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Description
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Description', {height: '300px'}) }}
+
+### Choice Card
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Choice Card', {height: '300px'}) }}
+
+### Fieldset
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Fieldset', {height: '300px'}) }}
+
+### Disabled
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '250px'}) }}
+
+### Invalid
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Invalid', {height: '300px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '300px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
-->

Companion PR to symfony/ux#3464. Adds the Toolkit/Shadcn docs page for the `radio-group` recipe.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.