### PR TITLE
[Toolkit][Shadcn] Add docs page for toggle-group

### DIFF
--- a/templates/toolkit/docs/shadcn/toggle-group.md.twig
+++ b/templates/toolkit/docs/shadcn/toggle-group.md.twig
@@ -1,0 +1,39 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Outline
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Outline', {height: '100px'}) }}
+
+### Sizes
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Sizes', {height: '200px'}) }}
+
+### Vertical
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '200px'}) }}
+
+### Spacing
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Spacing', {height: '100px'}) }}
+
+### Disabled
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '100px'}) }}
+
+### Font Weight Selector
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Font Weight Selector', {height: '250px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '250px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
-->

Companion PR to symfony/ux#3464. Adds the Toolkit/Shadcn docs page for the `toggle-group` recipe.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.