### PR TITLE
[Toolkit][Shadcn] Add docs page for collapsible

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -2,6 +2,7 @@ import './styles/toolkit-shadcn.css';
 import { startStimulusApp } from '@symfony/stimulus-bundle';
 import Accordion from '@symfony/ux-toolkit/kits/shadcn/accordion/assets/controllers/accordion_controller.js';
 import AlertDialog from '@symfony/ux-toolkit/kits/shadcn/alert-dialog/assets/controllers/alert_dialog_controller.js';
+import Collapsible from '@symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js';
 import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js';
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
@@ -10,6 +11,7 @@ import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/to
 const app = startStimulusApp();
 app.register('accordion', Accordion);
 app.register('alert-dialog', AlertDialog);
+app.register('collapsible', Collapsible);
 app.register('dialog', Dialog);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);

--- a/composer.lock
+++ b/composer.lock
@@ -8002,12 +8002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "27d0bef5a232c850d24ff3a15a1835cecf98c5f6"
+                "reference": "d0a47b708bdbb6565b040276c424e24d12f3853f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/27d0bef5a232c850d24ff3a15a1835cecf98c5f6",
-                "reference": "27d0bef5a232c850d24ff3a15a1835cecf98c5f6",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/d0a47b708bdbb6565b040276c424e24d12f3853f",
+                "reference": "d0a47b708bdbb6565b040276c424e24d12f3853f",
                 "shasum": ""
             },
             "require": {
@@ -8102,7 +8102,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-17T05:34:44+00:00"
+            "time": "2026-04-18T13:13:16+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/importmap.php
+++ b/importmap.php
@@ -195,6 +195,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/collapsible.md.twig
+++ b/templates/toolkit/docs/shadcn/collapsible.md.twig
@@ -1,0 +1,31 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Basic
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '300px'}) }}
+
+### Settings Panel
+
+Use a trigger button to reveal additional settings.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Settings Panel', {height: '300px'}) }}
+
+### File Tree
+
+Use nested collapsibles to build a file tree.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'File Tree', {height: '500px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '300px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
-->

Companion PR to symfony/ux#3464. Adds the Toolkit/Shadcn docs page for the `collapsible` recipe.

Also wires the Stimulus `Collapsible` controller in `assets/toolkit-shadcn.js` and `importmap.php` so the interactive demo on the docs page actually works (addition originally contributed by @Kocal on the previous #54).

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.