### PR TITLE
[Toolkit][Shadcn] Add docs page for native-select

### DIFF
--- a/templates/toolkit/docs/shadcn/native-select.md.twig
+++ b/templates/toolkit/docs/shadcn/native-select.md.twig
@@ -1,0 +1,27 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Groups
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Groups', {height: '100px'}) }}
+
+### Disabled
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '100px'}) }}
+
+### Invalid
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Invalid', {height: '100px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '160px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3479
| License        | MIT

Companion PR to symfony/ux#3466. Adds the Toolkit/Shadcn docs page for the `native-select` recipe.

Kept as **draft** until symfony/ux#3466 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.