### PR TITLE
[Toolkit][Shadcn] Add docs page for slider

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -6,6 +6,8 @@ import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/di
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
+import Slider from '@symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_controller.js';
+import SliderDisplay from '@symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_display_controller.js';
 
 const app = startStimulusApp();
 app.register('accordion', Accordion);
@@ -14,3 +16,5 @@ app.register('dialog', Dialog);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);
+app.register('slider', Slider);
+app.register('slider-display', SliderDisplay);

--- a/importmap.php
+++ b/importmap.php
@@ -204,6 +204,12 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_controller.js',
+    ],
+    '@symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_display_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/slider/assets/controllers/slider_display_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/slider.md.twig
+++ b/templates/toolkit/docs/shadcn/slider.md.twig
@@ -1,0 +1,35 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Range
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Range', {height: '80px'}) }}
+
+### Multiple Thumbs
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Multiple', {height: '80px'}) }}
+
+### Vertical
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '220px'}) }}
+
+### Controlled
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Controlled', {height: '120px'}) }}
+
+### Disabled
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '80px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '120px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3481
| License        | MIT

Companion PR to symfony/ux#3466. Adds the Toolkit/Shadcn docs page for the `slider` recipe.

Kept as **draft** until symfony/ux#3466 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.