### PR TITLE
[Toolkit][Shadcn] Add docs page for scroll-area

### DIFF
--- a/templates/toolkit/docs/shadcn/scroll-area.md.twig
+++ b/templates/toolkit/docs/shadcn/scroll-area.md.twig
@@ -1,0 +1,19 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Horizontal
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Horizontal', {height: '550px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '350px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3480
| License        | MIT

Companion PR to symfony/ux#3466. Adds the Toolkit/Shadcn docs page for the `scroll-area` recipe.

Kept as **draft** until symfony/ux#3466 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.