### PR TITLE
[Toolkit][Shadcn] Add docs page for hover-card

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -4,6 +4,7 @@ import Accordion from '@symfony/ux-toolkit/kits/shadcn/accordion/assets/controll
 import AlertDialog from '@symfony/ux-toolkit/kits/shadcn/alert-dialog/assets/controllers/alert_dialog_controller.js';
 import Collapsible from '@symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js';
 import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js';
+import HoverCard from '@symfony/ux-toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js';
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
 import Resizable from '@symfony/ux-toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
@@ -15,6 +16,7 @@ app.register('accordion', Accordion);
 app.register('alert-dialog', AlertDialog);
 app.register('collapsible', Collapsible);
 app.register('dialog', Dialog);
+app.register('hover-card', HoverCard);
 app.register('resizable', Resizable);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);

--- a/composer.lock
+++ b/composer.lock
@@ -8002,12 +8002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "2d815eee8188fd2f96c1d1433a921e34b6a46c5b"
+                "reference": "3e92e407f8b031686b1a09d38111455e073fdd2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/2d815eee8188fd2f96c1d1433a921e34b6a46c5b",
-                "reference": "2d815eee8188fd2f96c1d1433a921e34b6a46c5b",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/3e92e407f8b031686b1a09d38111455e073fdd2a",
+                "reference": "3e92e407f8b031686b1a09d38111455e073fdd2a",
                 "shasum": ""
             },
             "require": {
@@ -8102,7 +8102,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T12:15:34+00:00"
+            "time": "2026-04-27T05:47:50+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/importmap.php
+++ b/importmap.php
@@ -198,6 +198,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/hover-card/assets/controllers/hover_card_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/hover-card.md.twig
+++ b/templates/toolkit/docs/shadcn/hover-card.md.twig
@@ -1,0 +1,19 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Sides
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Sides', {height: '350px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '700px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3478
| License        | MIT

Companion PR to symfony/ux#3466. Adds the Toolkit/Shadcn docs page for the `hover-card` recipe.

Kept as **draft** until symfony/ux#3466 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.