### PR TITLE
[Toolkit][Shadcn] Add docs page for resizable

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -5,6 +5,7 @@ import AlertDialog from '@symfony/ux-toolkit/kits/shadcn/alert-dialog/assets/con
 import Collapsible from '@symfony/ux-toolkit/kits/shadcn/collapsible/assets/controllers/collapsible_controller.js';
 import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/dialog_controller.js';
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
+import Resizable from '@symfony/ux-toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
 import ToggleGroup from '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js';
@@ -14,6 +15,7 @@ app.register('accordion', Accordion);
 app.register('alert-dialog', AlertDialog);
 app.register('collapsible', Collapsible);
 app.register('dialog', Dialog);
+app.register('resizable', Resizable);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);

--- a/composer.lock
+++ b/composer.lock
@@ -8002,12 +8002,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "d0a47b708bdbb6565b040276c424e24d12f3853f"
+                "reference": "2d815eee8188fd2f96c1d1433a921e34b6a46c5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/d0a47b708bdbb6565b040276c424e24d12f3853f",
-                "reference": "d0a47b708bdbb6565b040276c424e24d12f3853f",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/2d815eee8188fd2f96c1d1433a921e34b6a46c5b",
+                "reference": "2d815eee8188fd2f96c1d1433a921e34b6a46c5b",
                 "shasum": ""
             },
             "require": {
@@ -8102,7 +8102,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:13:16+00:00"
+            "time": "2026-04-26T12:15:34+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/importmap.php
+++ b/importmap.php
@@ -207,6 +207,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/resizable/assets/controllers/resizable_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/resizable.md.twig
+++ b/templates/toolkit/docs/shadcn/resizable.md.twig
@@ -1,0 +1,23 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Vertical
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '260px'}) }}
+
+### Handle
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Handle', {height: '260px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '600px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3485
| License        | MIT

Companion PR to symfony/ux#3467. Adds the Toolkit/Shadcn docs page for the `resizable` recipe.

Kept as **draft** until symfony/ux#3467 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.