### PR TITLE
[Toolkit][Shadcn] Add docs page for popover

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -6,6 +6,7 @@ import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/di
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
+import Popover from '@symfony/ux-toolkit/kits/shadcn/popover/assets/controllers/popover_controller.js';
 
 const app = startStimulusApp();
 app.register('accordion', Accordion);
@@ -14,3 +15,4 @@ app.register('dialog', Dialog);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);
+app.register('popover', Popover);

--- a/importmap.php
+++ b/importmap.php
@@ -204,6 +204,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/popover/assets/controllers/popover_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/popover/assets/controllers/popover_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/popover.md.twig
+++ b/templates/toolkit/docs/shadcn/popover.md.twig
@@ -1,0 +1,27 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '550px'}) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Basic
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '250px'}) }}
+
+### Align
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Alignments', {height: '200px'}) }}
+
+### With Form
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Form', {height: '350px'}) }}
+
+### RTL
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '600px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3487
| License        | MIT

Companion PR to symfony/ux#3468. Adds the Toolkit/Shadcn docs page for the `popover` recipe.

Kept as **draft** until symfony/ux#3468 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.