### PR TITLE
[Toolkit][Shadcn] Add docs page for form

### DIFF
--- a/templates/toolkit/docs/shadcn/form.md.twig
+++ b/templates/toolkit/docs/shadcn/form.md.twig
@@ -1,0 +1,9 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to symfony/ux#3473
| License        | MIT

Companion PR to symfony/ux#3473. Adds the Toolkit/Shadcn docs page for the `form` recipe.

Kept as **draft** until symfony/ux#3473 (which introduces the upstream recipe) is merged.

Split out from the original #54 so each component can be reviewed/merged independently alongside its upstream recipe.