### PR TITLE
[Toolkit][Shadcn] Register toggle-group Stimulus controller

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -7,6 +7,7 @@ import Dialog from '@symfony/ux-toolkit/kits/shadcn/dialog/assets/controllers/di
 import Tabs from '@symfony/ux-toolkit/kits/shadcn/tabs/assets/controllers/tabs_controller.js';
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
+import ToggleGroup from '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js';
 
 const app = startStimulusApp();
 app.register('accordion', Accordion);
@@ -16,3 +17,4 @@ app.register('dialog', Dialog);
 app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);
+app.register('toggle-group', ToggleGroup);

--- a/importmap.php
+++ b/importmap.php
@@ -207,6 +207,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js',
     ],


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Follow-up to #60
| License        | MIT

The `toggle-group` recipe ships a Stimulus controller that enforces `type="single"` behaviour (only one item pressed at a time). It was not registered in `assets/toolkit-shadcn.js` / `importmap.php`, so the `Outline` example (and any other `type="single"` usage) behaved like `type="multiple"`.

Registers it the same way `collapsible` was registered in #61.