### PR TITLE
[Toolkit] Add a "View as Markdown" link on recipe pages

### DIFF
--- a/templates/toolkit/component.html.twig
+++ b/templates/toolkit/component.html.twig
@@ -26,14 +26,23 @@
         {{ include('toolkit/_kit_aside.html.twig') }}
 
         <div>
-            <nav aria-label="breadcrumb">
-                <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{{ path('app_toolkit') }}">UX Toolkit</a></li>
-                    <li class="breadcrumb-item"><a href="{{ path('app_toolkit', {_fragment: 'kits'}) }}">Kits</a></li>
-                    <li class="breadcrumb-item"><a href="{{ path('app_toolkit_kit', {kitId: kit_id.value}) }}">{{ kit.manifest.name }}</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">{{ component.manifest.name }}</li>
-                </ol>
-            </nav>
+            <div class="flex items-center justify-between gap-4 flex-wrap">
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a href="{{ path('app_toolkit') }}">UX Toolkit</a></li>
+                        <li class="breadcrumb-item"><a href="{{ path('app_toolkit', {_fragment: 'kits'}) }}">Kits</a></li>
+                        <li class="breadcrumb-item"><a href="{{ path('app_toolkit_kit', {kitId: kit_id.value}) }}">{{ kit.manifest.name }}</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ component.manifest.name }}</li>
+                    </ol>
+                </nav>
+
+                <a href="{{ path('app_toolkit_component', {kitId: kit_id.value, componentName: component.name}) }}.md"
+                   class="inline-flex items-center gap-2 text-sm text-foreground/80 hover:text-foreground underline-offset-4 hover:underline"
+                   title="View this page as Markdown (useful for LLMs)">
+                    <twig:ux:icon name="lucide:file-text" class="size-4" />
+                    View as Markdown
+                </a>
+            </div>
 
             <twig:Toolkit:ComponentDoc kitId="{{ kit_id }}" component="{{ component }}" />
         </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #25
| License        | MIT

Adds a small "View as Markdown" link on the Toolkit recipe pages (next to the breadcrumb), pointing to the existing `.md` variant of the page (already served by `MarkdownContentNegotiationListener` since #77).

The link uses a `lucide:file-text` icon and degrades gracefully on narrower viewports thanks to `flex-wrap`.

### Screenshot

| Before | After |
|---|---|
| _no link_ | breadcrumb on the left, "View as Markdown" link on the right |

### Question for @Kocal

The same `.md` content negotiation is available on a lot of other pages (changelog, packages, demos, cookbook, individual UX package pages...). Would you like this PR extended to also surface the link on those pages, or do you prefer to keep this one focused on Toolkit recipes and open a follow-up for the rest?

Happy to do either — just let me know!