### PR TITLE
[Toolkit][Shadcn] Align `card` with shadcn reference

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8014,12 +8014,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "56f18689898cfe94d4a6c877c286f089cf0ba904"
+                "reference": "8892ca7364f633e6e3a2f191be31b316d3a110d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/56f18689898cfe94d4a6c877c286f089cf0ba904",
-                "reference": "56f18689898cfe94d4a6c877c286f089cf0ba904",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/8892ca7364f633e6e3a2f191be31b316d3a110d8",
+                "reference": "8892ca7364f633e6e3a2f191be31b316d3a110d8",
                 "shasum": ""
             },
             "require": {
@@ -8114,7 +8114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T11:21:58+00:00"
+            "time": "2026-05-23T18:10:16+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/templates/toolkit/docs/shadcn/card.md.twig
+++ b/templates/toolkit/docs/shadcn/card.md.twig
@@ -1,9 +1,29 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '500px'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Size
+
+Use the `size="sm"` prop to set the size of the card to small. The small size variant uses smaller spacing.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Size', {height: '400px'}) }}
+
+### Image
+
+Add an image before the card header to create a card with an image.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Image', {height: '550px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '900px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3538

| Before | After| 
|--------|--------|
| <img width="100%" alt="FireShot Capture 002 - Component Card - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/7676e7b1-8a99-41a9-b364-8b7d3e8cd206" /> | <img width="100%" alt="FireShot Capture 001 - Component Card - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/749f3fea-fb43-4e6f-a50a-7bb28e97c75f" /> |
