### PR TITLE
[Toolkit][Shadcn] Align `separator` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/separator.md.twig
+++ b/templates/toolkit/docs/shadcn/separator.md.twig
@@ -7,3 +7,29 @@
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
 {% endblock %}
+
+{% block examples %}
+### Vertical
+
+Use `orientation="vertical"` for a vertical separator.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical') }}
+
+### Menu
+
+Vertical separators between menu items with descriptions.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Menu') }}
+
+### List
+
+Horizontal separators between list items.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'List') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '350px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3539

| Before | After |
|--------|--------|
| <img width="1920" height="1526" alt="FireShot Capture 004 - Component Separator - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/31401c48-820a-435e-9e1f-d294fbf8832b" /> | <img width="1920" height="3029" alt="FireShot Capture 003 - Component Separator - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/872788f6-8fd9-4136-914b-f8195b35f37a" /> |
