### PR TITLE
[Toolkit][Shadcn] Align `alert` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/alert.md.twig
+++ b/templates/toolkit/docs/shadcn/alert.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -32,4 +32,10 @@ Use `Alert:Action` to add a button or other action element to the alert.
 You can customize the alert colors by adding custom classes such as `bg-amber-50 dark:bg-amber-950` to the `Alert` component.
 
 {{ toolkit_code_example(kit_id.value, component.name, 'Custom Colors') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '450px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3552

| Before | After |
|--------|--------|
| <img width="1920" height="3871" alt="FireShot Capture 008 - Component Alert - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/ecc126e9-4572-41dd-a9a0-818b9b61ec7f" /> | <img width="1920" height="4315" alt="FireShot Capture 009 - Component Alert - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/9b55cc05-2855-456c-b353-8097aaf940d5" /> |

