### PR TITLE
[Toolkit][Shadcn] Align `alert-dialog` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/alert-dialog.md.twig
+++ b/templates/toolkit/docs/shadcn/alert-dialog.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,12 +9,39 @@
 {% endblock %}
 
 {% block examples %}
-### Opened by default
-{{ toolkit_code_example(kit_id.value, component.name, 'Opened by default', {height: '400px'}) }}
+### Basic
 
-### With Tooltip
+A basic alert dialog with a title, description, and cancel and continue buttons.
 
-Combining `Dialog` with `Tooltip` requires merging their `*_trigger_attrs` attributes using the [`html_attr_merge`](https://twig.symfony.com/doc/3.x/filters/html_attr_merge.html) Twig filter, available in `twig/html-extra:^3.24`.
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '300px'}) }}
 
-{{ toolkit_code_example(kit_id.value, component.name, 'With Tooltip', {height: '400px'}) }}
+### Small
+
+Use the `size="sm"` prop to make the alert dialog smaller.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Small', {height: '300px'}) }}
+
+### Media
+
+Use the `AlertDialog:Media` component to add a media element such as an icon or image to the alert dialog.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Media', {height: '300px'}) }}
+
+### Small with Media
+
+Use the `size="sm"` prop to make the alert dialog smaller and the `AlertDialog:Media` component to add a media element such as an icon or image to the alert dialog.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Small with Media', {height: '350px'}) }}
+
+### Destructive
+
+Use the `AlertDialog:Action` component to add a destructive action button to the alert dialog.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Destructive', {height: '350px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '350px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

<!--
Replace this notice by a description of your feature/bugfix.
-->

Companion of https://github.com/symfony/ux/pull/3553

| Before | After |
|--------|--------|
| <img width="1920" height="4764" alt="FireShot Capture 011 - Component Alert Dialog - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/4dc03ffc-075d-4758-a5e0-bb6d27aef64b" /> | <img width="1920" height="6971" alt="FireShot Capture 010 - Component Alert Dialog - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/44981000-4924-402b-888d-db612ae98949" /> |
