### PR TITLE
[Toolkit][Shadcn] Align `aspect-ratio` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/aspect-ratio.md.twig
+++ b/templates/toolkit/docs/shadcn/aspect-ratio.md.twig
@@ -1,9 +1,29 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '350px'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Square
+
+A square aspect ratio component using the `ratio="1 / 1"` prop. This is useful for displaying images in a square format.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Square', {height: '300px'}) }}
+
+### Portrait
+
+A portrait aspect ratio component using the `ratio="9 / 16"` prop. This is useful for displaying images in a portrait format.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Portrait', {height: '400px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '600px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3554

| Before | After |
|--------|--------|
| <img width="1920" height="1805" alt="FireShot Capture 013 - Component Aspect Ratio - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/5e4dae6c-e2bb-40db-a9dd-2a330928d1e8" /> | <img width="1920" height="3486" alt="FireShot Capture 012 - Component Aspect Ratio - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/d6a99d88-ae1e-425f-b044-88e5af7c0b21" /> |
