### PR TITLE
[Toolkit][Shadcn] Align `avatar` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/avatar.md.twig
+++ b/templates/toolkit/docs/shadcn/avatar.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '150px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,20 +10,50 @@
 
 {% block examples %}
 ### Basic
-{{ toolkit_code_example(kit_id.value, component.name, 'Basic') }}
+
+A basic avatar component with an image and a fallback.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '150px'}) }}
 
 ### Badge
-{{ toolkit_code_example(kit_id.value, component.name, 'Badge') }}
+
+Use the `Avatar:Badge` component to add a badge to the avatar. The badge is positioned at the bottom right of the avatar.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Badge', {height: '150px'}) }}
 
 ### Badge with Icon
-{{ toolkit_code_example(kit_id.value, component.name, 'Badge with Icon') }}
+
+You can also use an icon inside `Avatar:Badge`.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Badge with Icon', {height: '150px'}) }}
 
 ### Avatar Group
-{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group') }}
+
+Use the `Avatar:Group` component to add a group of avatars.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group', {height: '150px'}) }}
+
+### Avatar Group Count
+
+Use `Avatar:GroupCount` to add a count to the group.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group Count', {height: '150px'}) }}
 
 ### Avatar Group with Icon
-{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group with Icon') }}
+
+You can also use an icon inside `Avatar:GroupCount`.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group with Icon', {height: '150px'}) }}
 
 ### Sizes
-{{ toolkit_code_example(kit_id.value, component.name, 'Sizes') }}
+
+Use the `size` prop to change the size of the avatar.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Sizes', {height: '150px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3555

| Before | After |
|--------|--------|
| <img width="1920" height="4345" alt="FireShot Capture 014 - Component Avatar - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/369593c3-a7bc-4f39-8885-4e06ede4b517" /> | <img width="1920" height="4684" alt="FireShot Capture 015 - Component Avatar - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/0ddaae3f-9897-4480-8516-cc6fa421b6c4" /> |