### PR TITLE
[Toolkit][Shadcn] Align `badge` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/badge.md.twig
+++ b/templates/toolkit/docs/shadcn/badge.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '150px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,6 +9,39 @@
 {% endblock %}
 
 {% block examples %}
-### As link
-{{ toolkit_code_example(kit_id.value, component.name, 'As link') }}
+### Variants
+
+Use the `variant` prop to change the variant of the badge.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Variants', {height: '150px'}) }}
+
+### With Icon
+
+You can render an icon inside the badge. Use `data-icon="inline-start"` to render the icon on the left and `data-icon="inline-end"` to render the icon on the right.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'With Icon', {height: '150px'}) }}
+
+### With Spinner
+
+You can render a spinner inside the badge. Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` attribute to the spinner.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'With Spinner', {height: '150px'}) }}
+
+### Link
+
+Use the `as` prop to render a link as a badge.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Link', {height: '150px'}) }}
+
+### Custom Colors
+
+You can customize the colors of a badge by adding custom classes such as `bg-green-50 dark:bg-green-800` to the `Badge` component.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Custom Colors', {height: '150px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3556

| Before | After |
|--------|--------|
| <img width="1920" height="2057" alt="FireShot Capture 017 - Component Badge - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/f50c52a9-3427-4c89-9a1d-5ac531532888" /> | <img width="1920" height="3502" alt="FireShot Capture 016 - Component Badge - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/4c0ac665-9170-42b4-b311-ee563e3584a3" /> |