### PR TITLE
[Toolkit][Shadcn] Align `breadcrumb` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/breadcrumb.md.twig
+++ b/templates/toolkit/docs/shadcn/breadcrumb.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '150px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,6 +9,33 @@
 {% endblock %}
 
 {% block examples %}
-### Custom Separator
-{{ toolkit_code_example(kit_id.value, component.name, 'Custom Separator') }}
+### Basic
+
+A basic breadcrumb with a home link and a components link.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '150px'}) }}
+
+### Custom separator
+
+Use a custom component as `children` for `Breadcrumb:Separator` to create a custom separator.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Custom Separator', {height: '150px'}) }}
+
+### Collapsed
+
+We provide a `Breadcrumb:Ellipsis` component to show a collapsed state when the breadcrumb is too long.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Collapsed', {height: '150px'}) }}
+
+### Link component
+
+To use a custom link component from your routing library, you can pass the `href` attribute to `Breadcrumb:Link`.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Link component', {height: '150px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3557

| Before | After |
|--------|--------|
| <img width="1920" height="3082" alt="FireShot Capture 018 - Component Breadcrumb - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/2c0d4654-9440-41ba-8196-1654245b7984" /> | <img width="1920" height="4258" alt="FireShot Capture 019 - Component Breadcrumb - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/0221775b-2d63-4746-8839-30e3263cfba0" /> |