### PR TITLE
[Toolkit][Shadcn] Align `toggle` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/toggle.md.twig
+++ b/templates/toolkit/docs/shadcn/toggle.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '150px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,14 +10,28 @@
 
 {% block examples %}
 ### Outline
-{{ toolkit_code_example(kit_id.value, component.name, 'Outline') }}
+
+Use `variant="outline"` for an outline style.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Outline', {height: '150px'}) }}
 
 ### With Text
-{{ toolkit_code_example(kit_id.value, component.name, 'With Text') }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'With Text', {height: '150px'}) }}
 
 ### Size
-{{ toolkit_code_example(kit_id.value, component.name, 'Size') }}
+
+Use the `size` prop to change the size of the toggle.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Size', {height: '150px'}) }}
 
 ### Disabled
-{{ toolkit_code_example(kit_id.value, component.name, 'Disabled') }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '150px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #...
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3560

| Before | After |
|--------|-------|
|  <img width="1920" height="3157" alt="FireShot Capture 025 - Component Toggle - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/2ebb6776-4060-4fbe-bc74-2df1c025594e" />   |    <img width="1920" height="3106" alt="FireShot Capture 024 - Component Toggle - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/92f1ff04-d9b3-4ce3-b9cd-43f6796aaaba" />  |