### PR TITLE
[Toolkit][Shadcn] Align `table` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/table.md.twig
+++ b/templates/toolkit/docs/shadcn/table.md.twig
@@ -1,9 +1,23 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '30rem'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Footer
+
+Use the `TableFooter` component to add a footer to the table.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Footer', {height: '300px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '550px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3561

| Before | After |
|--------|-------|
|   <img width="1920" height="3159" alt="FireShot Capture 027 - Component Table - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/01e28120-3a74-4952-ae76-ae53d2adad8a" />     |  <img width="1920" height="4419" alt="FireShot Capture 026 - Component Table - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/96ee6fa8-be29-404a-b786-2abe07099c0f" />  |