### PR TITLE
[Toolkit][Shadcn] Align `skeleton` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/skeleton.md.twig
+++ b/templates/toolkit/docs/shadcn/skeleton.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,6 +9,24 @@
 {% endblock %}
 
 {% block examples %}
+### Avatar
+{{ toolkit_code_example(kit_id.value, component.name, 'Avatar') }}
+
 ### Card
-{{ toolkit_code_example(kit_id.value, component.name, 'Card', {height: '300px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Card', {height: '350px'}) }}
+
+### Text
+{{ toolkit_code_example(kit_id.value, component.name, 'Text') }}
+
+### Form
+{{ toolkit_code_example(kit_id.value, component.name, 'Form', {height: '300px'}) }}
+
+### Table
+{{ toolkit_code_example(kit_id.value, component.name, 'Table') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '250px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3563

| Before | After |
|--------|-------|
|  <img width="1920" height="1724" alt="FireShot Capture 028 - Component Skeleton - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/51580182-c9ca-4847-b593-75c0df512c84" />      |  <img width="1920" height="3323" alt="FireShot Capture 029 - Component Skeleton - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/556bff4a-c8e6-49b1-95f1-701d13cd0d06" />   |