### PR TITLE
[Toolkit][Shadcn] Align `pagination` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/pagination.md.twig
+++ b/templates/toolkit/docs/shadcn/pagination.md.twig
@@ -1,9 +1,29 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Simple
+
+A simple pagination with only page numbers.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Simple') }}
+
+### Icons Only
+
+Use just the previous and next buttons without page numbers. This is useful for data tables with a rows per page selector.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Icons Only') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3564

| Before | After |
|--------|-------|
|    <img width="1920" height="2633" alt="FireShot Capture 031 - Component Pagination - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/a04196b7-9d25-400f-aca9-ac06a1c874ac" />   | <img width="1920" height="3878" alt="FireShot Capture 030 - Component Pagination - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/84a9755a-179e-4cf6-bcc8-236714054d10" />   |