### PR TITLE
[Toolkit][Shadcn] Align `tabs` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/tabs.md.twig
+++ b/templates/toolkit/docs/shadcn/tabs.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,9 +10,15 @@
 
 {% block examples %}
 ### Line
-{{ toolkit_code_example(kit_id.value, component.name, 'Variant Line') }}
+
+Use the `variant="line"` prop on `Tabs:List` for a line style.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Line') }}
 
 ### Vertical
+
+Use `orientation="vertical"` for vertical tabs.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Vertical') }}
 
 ### Disabled
@@ -20,4 +26,10 @@
 
 ### Icons
 {{ toolkit_code_example(kit_id.value, component.name, 'Icons') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '500px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3567

| Before | After |
|--------|-------|
|    <img width="1920" height="4093" alt="FireShot Capture 032 - Component Tabs - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/72802fd5-262d-473e-be42-1acbee6dbe81" />    |     <img width="1920" height="4691" alt="FireShot Capture 034 - Component Tabs - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/639ee515-bc70-48cb-931b-f362cb208eda" />  |