### PR TITLE
[Toolkit][Shadcn] Align `tooltip` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/tooltip.md.twig
+++ b/templates/toolkit/docs/shadcn/tooltip.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,11 +10,23 @@
 
 {% block examples %}
 ### Side
+
+Use the `side` prop to change the position of the tooltip.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Side') }}
 
 ### With Keyboard Shortcut
 {{ toolkit_code_example(kit_id.value, component.name, 'With Keyboard Shortcut') }}
 
 ### Disabled Button
+
+Show a tooltip on a disabled button by wrapping it with a span.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Disabled Button') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3568

| Before | After |
|--------|-------|
|    <img width="1920" height="3422" alt="FireShot Capture 036 - Component Tooltip - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/db182ec4-6dd9-4f93-adf9-2f1a69aa7d13" />    |   <img width="1920" height="3620" alt="FireShot Capture 035 - Component Tooltip - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/7458a63a-8e93-4d0d-83dd-ec9de3fe7e1d" />    |