### PR TITLE
[Toolkit][Shadcn] Align `textarea` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/textarea.md.twig
+++ b/templates/toolkit/docs/shadcn/textarea.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,15 +9,33 @@
 {% endblock %}
 
 {% block examples %}
-### Default
-{{ toolkit_code_example(kit_id.value, component.name, 'Default') }}
+### Field
+
+Use `Field`, `Field:Label`, and `Field:Description` to create a textarea with a label and description.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Field') }}
 
 ### Disabled
+
+Use the `disabled` attribute to disable the textarea. To style the disabled state, add the `data-disabled` attribute to the `Field` component.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Disabled') }}
 
-### With Label
-{{ toolkit_code_example(kit_id.value, component.name, 'With Label') }}
+### Invalid
 
-### With Text
-{{ toolkit_code_example(kit_id.value, component.name, 'With Text') }}
+Use the `aria-invalid` attribute to mark the textarea as invalid. To style the invalid state, add the `data-invalid` attribute to the `Field` component.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Invalid') }}
+
+### Button
+
+Pair with `Button` to create a textarea with a submit button.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Button') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '400px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3569

| Before | After |
|--------|-------|
|    <img width="1920" height="2815" alt="FireShot Capture 038 - Component Textarea - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/c962c4ec-d2b6-4ad1-b1e2-ac26ca4106c2" />   |   <img width="1920" height="3353" alt="FireShot Capture 037 - Component Textarea - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/b48a8d0c-b4b6-48f0-a451-177cad7695ca" />    |