### PR TITLE
[Toolkit][Shadcn] Align `resizable` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/resizable.md.twig
+++ b/templates/toolkit/docs/shadcn/resizable.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -11,13 +11,19 @@
 {% block examples %}
 ### Vertical
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '260px'}) }}
+Use `orientation="vertical"` for vertical resizing.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '300px'}) }}
 
 ### Handle
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Handle', {height: '260px'}) }}
+Use the `withHandle` prop on `Resizable:Handle` to show a visible handle.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Handle', {height: '300px'}) }}
 
 ### RTL
 
-{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '600px'}) }}
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '550px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3570

| Before | After |
|--------|-------|
|   <img width="1920" height="3732" alt="FireShot Capture 040 - Component Resizable - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/4f2703c4-6dc4-4d82-8159-5686ee81c75a" />   |<img width="1920" height="3741" alt="FireShot Capture 039 - Component Resizable - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/a83e18e7-b0e9-44c9-8774-29b7f8f20263" />   |