### PR TITLE
[Toolkit][Shadcn] Align `spinner` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/spinner.md.twig
+++ b/templates/toolkit/docs/shadcn/spinner.md.twig
@@ -11,14 +11,33 @@
 {% block examples %}
 ### Size
 
-Use the `size-` utility class to change the size of the spinner.
+Use the `size-*` utility class to change the size of the spinner.
 
 {{ toolkit_code_example(kit_id.value, component.name, 'Size') }}
 
-### Color
+### Button
 
-Use the `text-` utility class to change the color of the spinner.
+Add a spinner to a button to indicate a loading state. Place the `Spinner` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Color') }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Button') }}
 
+### Badge
+
+Add a spinner to a badge to indicate a loading state. Place the `Spinner` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Badge') }}
+
+### Input Group
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Input Group') }}
+
+### Empty
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Empty') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | 
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3573

| Before | After |
|--------|-------|
|    <img width="1920" height="2079" alt="FireShot Capture 041 - Component Spinner - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/509efe36-6c2f-4f5b-9cc0-4005fa971650" />    | <img width="1920" height="3448" alt="FireShot Capture 042 - Component Spinner - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/e639ab98-3c18-4107-a48c-deb92d63fe74" />    |