### PR TITLE
[Toolkit][Shadcn] Align `label` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/label.md.twig
+++ b/templates/toolkit/docs/shadcn/label.md.twig
@@ -7,3 +7,17 @@
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
 {% endblock %}
+
+{% block examples %}
+### Label in Field
+
+For form fields, use the `Field` component which includes built-in label, description, and error handling.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Field') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | 
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3574

| Before | After |
|--------|-------|
|     <img width="1920" height="1482" alt="FireShot Capture 043 - Component Label - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/6af1fc56-11b0-45c8-9cf4-61609b57b561" />   |    <img width="1920" height="2012" alt="FireShot Capture 044 - Component Label - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/eaea4522-610c-4126-83fe-577a44749533" />   |