### PR TITLE
[Toolkit][Shadcn] Align `checkbox` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/checkbox.md.twig
+++ b/templates/toolkit/docs/shadcn/checkbox.md.twig
@@ -1,9 +1,45 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '380px'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Basic
+
+Pair the checkbox with `Field` and `Field:Label` for proper layout and labeling.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic') }}
+
+### Description
+
+Use `Field:Content` and `Field:Description` for helper text.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Description') }}
+
+### Disabled
+
+Use the `disabled` attribute to prevent interaction and add the `data-disabled` attribute to the `Field` component for disabled styles.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled') }}
+
+### Group
+
+Use multiple fields to create a checkbox list.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Group', {height: '300px'}) }}
+
+### Table
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Table', {height: '300px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '680px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | 
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3575

| Before | After |
|--------|-------|
|   <img width="1920" height="1250" alt="FireShot Capture 045 - Component Checkbox - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/372bf84c-4aa8-4899-997a-3b0db5901c95" />   |<img width="1920" height="4073" alt="FireShot Capture 046 - Component Checkbox - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/d0aca639-6ef8-4f6f-95e7-dfc057b42b15" />   |