### PR TITLE
[Toolkit][Shadcn] Align `progress` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/progress.md.twig
+++ b/templates/toolkit/docs/shadcn/progress.md.twig
@@ -1,9 +1,23 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
 {{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Label
+
+Use a `Field` component to add a label to the progress bar.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Label') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL') }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | 
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3577

| Before | After |
|--------|-------|
|   <img width="1920" height="1482" alt="FireShot Capture 047 - Component Progress - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/b20e74a2-2edb-4f71-b360-1c89f8442152" />   | <img width="1920" height="2012" alt="FireShot Capture 048 - Component Progress - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/657077c0-9eb7-43ba-b2f1-52e05bcb2363" />  |