### PR TITLE
[Toolkit][Shadcn] Align `kbd` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/kbd.md.twig
+++ b/templates/toolkit/docs/shadcn/kbd.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,8 +10,32 @@
 
 {% block examples %}
 ### Group
+
+Use the `KbdGroup` component to group keyboard keys together.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Group') }}
 
 ### Button
+
+Use the `Kbd` component inside a `Button` component to display a keyboard key inside a button.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Button') }}
+
+### Tooltip
+
+You can use the `Kbd` component inside a `Tooltip` component to display a tooltip with a keyboard key.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Tooltip') }}
+
+### Input Group
+
+You can use the `Kbd` component inside an `InputGroup:Addon` component to display a keyboard key inside an input group.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'InputGroup') }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '300px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3581

| Before | After |
|--------|-------|
|    <img width="1920" height="2353" alt="FireShot Capture 049 - Component Kbd - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/0f574930-ac93-4bc1-a103-398a02e622d4" />    |<img width="1920" height="3377" alt="FireShot Capture 050 - Component Kbd - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/46ea66ae-855c-461c-a4f1-920c1997a222" />   |