### PR TITLE
[Toolkit][Shadcn] Align `collapsible` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/collapsible.md.twig
+++ b/templates/toolkit/docs/shadcn/collapsible.md.twig
@@ -23,9 +23,11 @@ Use a trigger button to reveal additional settings.
 
 Use nested collapsibles to build a file tree.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'File Tree', {height: '500px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'File Tree', {height: '600px'}) }}
 
 ### RTL
 
-{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '300px'}) }}
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '550px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3584

| Before | After |
|--------|-------|
|   <img width="1920" height="4079" alt="FireShot Capture 053 - Component Collapsible - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/14650a08-db4d-4c65-b7b0-25d1b1877ed6" /> |<img width="1920" height="4482" alt="FireShot Capture 054 - Component Collapsible - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/8b417be8-c5b3-4c9a-8523-439457ef95f8" />   |