### PR TITLE
[Toolkit][Shadcn] Align `empty` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/empty.md.twig
+++ b/templates/toolkit/docs/shadcn/empty.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -10,15 +10,38 @@
 
 {% block examples %}
 ### Outline
+
+Use the `border` utility class to create an outline empty state.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Outline', {height: '300px'}) }}
 
 ### Background
+
+Use the `bg-*` utilities to add a background to the empty state.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Background', {height: '300px'}) }}
 
 ### Avatar
+
+Use the `Empty:Media` component to display an avatar in the empty state.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Avatar', {height: '300px'}) }}
 
-### Avatar group
-{{ toolkit_code_example(kit_id.value, component.name, 'Avatar group', {height: '300px'}) }}
+### Avatar Group
 
+Use the `Empty:Media` component to display an avatar group in the empty state.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Avatar Group', {height: '300px'}) }}
+
+### InputGroup
+
+You can add an `InputGroup` component to the `Empty:Content` component.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'InputGroup', {height: '300px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '600px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3585

| Before | After |
|--------|-------|
|    <img width="1920" height="4477" alt="FireShot Capture 055 - Component Empty - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/d1a8b6af-fb93-4583-8cf9-8c472fc37004" />   |<img width="1920" height="5725" alt="FireShot Capture 056 - Component Empty - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/1ad5a13a-2953-4b9d-a3b3-0488bb433aa3" />    |