### PR TITLE
[Toolkit][Shadcn] Align `button-group` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/button-group.md.twig
+++ b/templates/toolkit/docs/shadcn/button-group.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -16,21 +16,53 @@
 
 {% block examples %}
 ### Orientation
+
+Set the `orientation` prop to change the button group layout.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Orientation', {height: '200px'}) }}
 
 ### Size
-{{ toolkit_code_example(kit_id.value, component.name, 'Size', {height: '420px'}) }}
 
-### Input
-{{ toolkit_code_example(kit_id.value, component.name, 'Input', {height: '200px'}) }}
+Control the size of buttons using the `size` prop on individual buttons.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Size', {height: '300px'}) }}
 
 ### Nested
-{{ toolkit_code_example(kit_id.value, component.name, 'Nested', {height: '240px'}) }}
+
+Nest `ButtonGroup` components to create button groups with spacing.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Nested', {height: '200px'}) }}
 
 ### Separator
+
+The `ButtonGroup:Separator` component visually divides buttons within a group.
+
+Buttons with variant `outline` do not need a separator since they have a border. For other variants, a separator is recommended to improve the visual hierarchy.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Separator', {height: '200px'}) }}
 
 ### Split
+
+Create a split button group by adding two buttons separated by a `ButtonGroup:Separator`.
+
 {{ toolkit_code_example(kit_id.value, component.name, 'Split', {height: '200px'}) }}
+
+### Input
+
+Wrap an `Input` component with buttons.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Input', {height: '200px'}) }}
+
+### Input Group
+
+Wrap an `InputGroup` component to create complex input layouts.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Input Group', {height: '200px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '320px'}) }}
 
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3586

| Before | After |
|--------|-------|
|   <img width="1920" height="4644" alt="FireShot Capture 057 - Component Button Group - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/1b6da01a-be81-4c0b-b4c9-17b41128632e" /> |<img width="1920" height="5407" alt="FireShot Capture 058 - Component Button Group - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/ec9b3363-1a8f-4b9f-b5b6-9d36cb9bbc4c" />
    |