### PR TITLE
[Toolkit][Shadcn] Align `hover-card` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/hover-card.md.twig
+++ b/templates/toolkit/docs/shadcn/hover-card.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,11 +9,17 @@
 {% endblock %}
 
 {% block examples %}
+### Basic
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Basic', {height: '300px'}) }}
+
 ### Sides
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Sides', {height: '350px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Sides', {height: '300px'}) }}
 
 ### RTL
 
-{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '700px'}) }}
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '400px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3587

| Before | After |
|--------|-------|
|    <img width="1920" height="3599" alt="FireShot Capture 059 - Component Hover Card - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/05f0d601-44f5-41ad-96bd-24b231591a15" />  | <img width="1920" height="3671" alt="FireShot Capture 060 - Component Hover Card - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/f45487d8-8173-4a22-8373-e2880a3468f9" />     |