### PR TITLE
[Toolkit][Shadcn] Align `toggle-group` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/toggle-group.md.twig
+++ b/templates/toolkit/docs/shadcn/toggle-group.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -11,29 +11,27 @@
 {% block examples %}
 ### Outline
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Outline', {height: '100px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Outline') }}
 
-### Sizes
+### Size
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Sizes', {height: '200px'}) }}
-
-### Vertical
-
-{{ toolkit_code_example(kit_id.value, component.name, 'Vertical', {height: '200px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Size') }}
 
 ### Spacing
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Spacing', {height: '100px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Spacing') }}
+
+### Vertical
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Vertical') }}
 
 ### Disabled
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Disabled', {height: '100px'}) }}
-
-### Font Weight Selector
-
-{{ toolkit_code_example(kit_id.value, component.name, 'Font Weight Selector', {height: '250px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled') }}
 
 ### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
 
 {{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '250px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3589

| Before | After |
|--------|-------|
| <img width="1920" height="4251" alt="FireShot Capture 063 - Component Toggle Group - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/0970188d-1ee9-4b65-a22f-eb1b1578c357" /> |<img width="1920" height="4106" alt="FireShot Capture 064 - Component Toggle Group - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/e2372ff3-cbf8-4cf2-92ca-f4b7032a2661" />    |