### PR TITLE
[Toolkit][Shadcn] Align `field` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/field.md.twig
+++ b/templates/toolkit/docs/shadcn/field.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name, {height: '850px'}) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '700px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,26 +9,43 @@
 {% endblock %}
 
 {% block examples %}
-
 ### Input
-{{ toolkit_code_example(kit_id.value, component.name, 'Input', {height: '500px'}) }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Input', {height: '300px'}) }}
 
 ### Textarea
-{{ toolkit_code_example(kit_id.value, component.name, 'Textarea', {height: '400px'}) }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Textarea', {height: '220px'}) }}
 
 ### Select
-{{ toolkit_code_example(kit_id.value, component.name, 'Select', {height: '360px'}) }}
 
-### Field set
-{{ toolkit_code_example(kit_id.value, component.name, 'Field set', {height: '400px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Select', {height: '200px'}) }}
+
+### Fieldset
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Field set', {height: '350px'}) }}
 
 ### Checkbox
-{{ toolkit_code_example(kit_id.value, component.name, 'Checkbox', {height: '520px'}) }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Checkbox', {height: '350px'}) }}
 
 ### Switch
-{{ toolkit_code_example(kit_id.value, component.name, 'Switch', {height: '240px'}) }}
 
-### Field group
-{{ toolkit_code_example(kit_id.value, component.name, 'Field group', {height: '520px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Switch', {height: '200px'}) }}
 
+### Choice Card
+
+Wrap `Field` components inside `Field:Label` to create selectable field groups. This works with `RadioGroup:Item`, `Checkbox`, and `Switch` components.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Choice Card', {height: '300px'}) }}
+
+### Field Group
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Field group', {height: '350px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '700px'}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no existing issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3592

| Before | After |
|--------|-------|
|   <img width="1920" height="8097" alt="FireShot Capture 070 - Component Field - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/b2a24701-c1e6-43dd-b98f-3358e08d6c88" />   | <img width="1920" height="8330" alt="FireShot Capture 069 - Component Field - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/90804eff-0d53-4e1b-832a-c65f8a67ac1b" />     |