### PR TITLE
[Toolkit][Shadcn] Align `input-group` with shadcn reference

### DIFF
--- a/templates/toolkit/docs/shadcn/input-group.md.twig
+++ b/templates/toolkit/docs/shadcn/input-group.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '200px'}) }}
 {% endblock %}
 
 {% block usage %}
@@ -9,29 +9,34 @@
 {% endblock %}
 
 {% block examples %}
-
 ### Icon
-{{ toolkit_code_example(kit_id.value, component.name, 'Icon', {height: '350px'}) }}
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Icon', {height: '300px'}) }}
 
 ### Text
-
-Display additional text information alongside inputs.
 
 {{ toolkit_code_example(kit_id.value, component.name, 'Text', {height: '400px'}) }}
 
 ### Button
-{{ toolkit_code_example(kit_id.value, component.name, 'Button', {height: '350px'}) }}
 
-### Textarea
-{{ toolkit_code_example(kit_id.value, component.name, 'Textarea', {height: '400px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Button', {height: '300px'}) }}
+
+### Kbd
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Kbd') }}
 
 ### Spinner
-{{ toolkit_code_example(kit_id.value, component.name, 'Spinner', {height: '400px'}) }}
 
-### Label
-{{ toolkit_code_example(kit_id.value, component.name, 'Label', {height: '300px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Spinner', {height: '300px'}) }}
 
-### Button Group
-{{ toolkit_code_example(kit_id.value, component.name, 'Button Group') }}
+### Textarea
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Textarea', {height: '400px'}) }}
+
+### RTL
+
+To enable RTL support, set the `dir="rtl"` attribute on the root element.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'RTL', {height: '850px'}) }}
 
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #<!-- no issue -->
| License        | MIT

Companion of https://github.com/symfony/ux/pull/3594

| Before | After |
|--------|-------|
| <img width="1920" height="6104" alt="FireShot Capture 073 - Component Input Group - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/d36939d5-7ec3-49c0-a6d5-76c6dda06635" />   |<img width="1920" height="6275" alt="FireShot Capture 074 - Component Input Group - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/2f428a51-22b6-4b14-8a0c-47f395827808" />   |