### PR TITLE
[Toolkit] Add table of contents to component documentation pages

### DIFF
--- a/assets/controllers/toolkit_recipe_toc_controller.js
+++ b/assets/controllers/toolkit_recipe_toc_controller.js
@@ -1,0 +1,87 @@
+import { Controller } from '@hotwired/stimulus';
+
+const ACTIVE_CLASS = 'active';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['link'];
+
+    connect() {
+        this.linkByHeading = new Map();
+        this.visible = new Set();
+
+        this.linkTargets.forEach((link) => {
+            const anchor = link.querySelector('a[href^="#"]');
+            const id = anchor ? decodeURIComponent(anchor.hash.slice(1)) : '';
+            const heading = id ? document.getElementById(id) : null;
+            if (heading) {
+                this.linkByHeading.set(heading, link);
+            }
+        });
+
+        if (this.linkByHeading.size === 0) {
+            return;
+        }
+
+        this.observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        this.visible.add(entry.target);
+                    } else {
+                        this.visible.delete(entry.target);
+                    }
+                });
+                this.activate();
+            },
+            { rootMargin: '0px 0px -70% 0px', threshold: 0 },
+        );
+
+        this.linkByHeading.forEach((_link, heading) => this.observer.observe(heading));
+        this.activate();
+    }
+
+    disconnect() {
+        this.observer?.disconnect();
+        this.visible?.clear();
+        this.linkByHeading?.clear();
+    }
+
+    activate() {
+        const activeHeading = this.pickActiveHeading();
+        const activeLink = activeHeading ? this.linkByHeading.get(activeHeading) : null;
+
+        this.linkByHeading.forEach((link) => {
+            const isActive = link === activeLink;
+            link.classList.toggle(ACTIVE_CLASS, isActive);
+            if (isActive) {
+                link.setAttribute('aria-current', 'page');
+            } else {
+                link.removeAttribute('aria-current');
+            }
+        });
+    }
+
+    pickActiveHeading() {
+        if (this.visible.size > 0) {
+            let top = null;
+            let topY = Infinity;
+            this.visible.forEach((heading) => {
+                const y = heading.getBoundingClientRect().top;
+                if (y < topY) {
+                    topY = y;
+                    top = heading;
+                }
+            });
+            return top;
+        }
+
+        let lastAbove = null;
+        this.linkByHeading.forEach((_link, heading) => {
+            if (heading.getBoundingClientRect().top <= 0) {
+                lastAbove = heading;
+            }
+        });
+        return lastAbove;
+    }
+}

--- a/assets/styles/app-tailwind.css
+++ b/assets/styles/app-tailwind.css
@@ -288,10 +288,6 @@
         background-color: inherit;
         padding: 0;
     }
-    a > code {
-        color: inherit;
-        background-color: inherit;
-    }
 
     .code-description :is(h2, h3) {
         font-family: var(--font-title);

--- a/config/reference.php
+++ b/config/reference.php
@@ -33,7 +33,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
@@ -78,7 +78,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     tags?: TagsType,
  *     resource_tags?: TagsType,
  *     decorates?: string,
- *     decorates_tag?: string,
  *     decoration_inner_name?: string,
  *     decoration_priority?: int,
  *     decoration_on_invalid?: 'exception'|'ignore'|null,
@@ -119,11 +118,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
  *     public?: bool,
  *     deprecated?: DeprecationType,
- *     decorates?: string,
- *     decorates_tag?: string,
- *     decoration_inner_name?: string,
- *     decoration_priority?: int,
- *     decoration_on_invalid?: 'exception'|'ignore'|null,
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
@@ -132,49 +126,49 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|Param|null,
+ *     secret?: scalar|null|Param,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: null|list<string|Param>,
- *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     allowed_http_method_override?: list<string|Param>|null,
+ *     trust_x_sendfile_type_header?: scalar|null|Param, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|null|Param, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
- *     default_locale?: scalar|Param|null, // Default: "en"
+ *     default_locale?: scalar|null|Param, // Default: "en"
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: string|list<scalar|Param|null>,
+ *     enabled_locales?: list<scalar|null|Param>,
+ *     trusted_hosts?: list<scalar|null|Param>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: string|list<scalar|Param|null>,
- *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     trusted_headers?: list<scalar|null|Param>,
+ *     error_controller?: scalar|null|Param, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|Param|null, // Default: null
- *         stateless_token_ids?: list<scalar|Param|null>,
- *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|null|Param, // Default: null
+ *         stateless_token_ids?: list<scalar|null|Param>,
+ *         check_header?: scalar|null|Param, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|null|Param, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
  *         enabled?: bool|Param, // Default: true
- *         csrf_protection?: bool|array{
- *             enabled?: scalar|Param|null, // Default: null
- *             token_id?: scalar|Param|null, // Default: null
- *             field_name?: scalar|Param|null, // Default: "_token"
- *             field_attr?: array<string, scalar|Param|null>,
+ *         csrf_protection?: array{
+ *             enabled?: scalar|null|Param, // Default: null
+ *             token_id?: scalar|null|Param, // Default: null
+ *             field_name?: scalar|null|Param, // Default: "_token"
+ *             field_attr?: array<string, scalar|null|Param>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
  *         enabled?: bool|Param, // Default: false
  *         debug?: bool|Param, // Default: "%kernel.debug%"
  *         trace_level?: "none"|"short"|"full"|Param,
- *         trace_header?: scalar|Param|null,
+ *         trace_header?: scalar|null|Param,
  *         default_ttl?: int|Param,
- *         private_headers?: list<scalar|Param|null>,
- *         skip_response_headers?: list<scalar|Param|null>,
+ *         private_headers?: list<scalar|null|Param>,
+ *         skip_response_headers?: list<scalar|null|Param>,
  *         allow_reload?: bool|Param,
  *         allow_revalidate?: bool|Param,
  *         stale_while_revalidate?: int|Param,
  *         stale_if_error?: int|Param,
- *         terminate_on_cache_hit?: bool|Param, // Deprecated: Setting the "framework.http_cache.terminate_on_cache_hit.terminate_on_cache_hit" configuration option is deprecated. It will be removed in version 9.0.
+ *         terminate_on_cache_hit?: bool|Param,
  *     },
  *     esi?: bool|array{ // ESI configuration
  *         enabled?: bool|Param, // Default: false
@@ -184,17 +178,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     fragments?: bool|array{ // Fragments configuration
  *         enabled?: bool|Param, // Default: false
- *         hinclude_default_template?: scalar|Param|null, // Default: null
- *         path?: scalar|Param|null, // Default: "/_fragment"
+ *         hinclude_default_template?: scalar|null|Param, // Default: null
+ *         path?: scalar|null|Param, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
  *         enabled?: bool|Param, // Default: false
  *         collect?: bool|Param, // Default: true
- *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         collect_parameter?: scalar|null|Param, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
- *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: true|Param, // Deprecated: Setting the "framework.profiler.collect_serializer_data.collect_serializer_data" configuration option is deprecated. It will be removed in version 9.0. // Default: true
+ *         dsn?: scalar|null|Param, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: true|Param, // Default: true
  *     },
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -205,165 +199,164 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
  *                 type?: "method"|Param,
- *                 property?: scalar|Param|null,
- *                 service?: scalar|Param|null,
+ *                 property?: scalar|null|Param,
+ *                 service?: scalar|null|Param,
  *             },
- *             supports?: string|list<scalar|Param|null>,
- *             definition_validators?: list<scalar|Param|null>,
- *             support_strategy?: scalar|Param|null,
- *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
- *             events_to_dispatch?: null|list<string|Param>,
- *             places?: string|list<array{ // Default: []
- *                 name?: scalar|Param|null,
- *                 metadata?: array<string, mixed>,
+ *             supports?: list<scalar|null|Param>,
+ *             definition_validators?: list<scalar|null|Param>,
+ *             support_strategy?: scalar|null|Param,
+ *             initial_marking?: list<scalar|null|Param>,
+ *             events_to_dispatch?: list<string|Param>|null,
+ *             places?: list<array{ // Default: []
+ *                 name: scalar|null|Param,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             transitions?: list<array{ // Default: []
- *                 name?: string|Param,
+ *             transitions: list<array{ // Default: []
+ *                 name: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
+ *                 from?: list<array{ // Default: []
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: \BackedEnum|string|list<array{ // Default: []
- *                     place?: string|Param,
+ *                 to?: list<array{ // Default: []
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 weight?: int|Param, // Default: 1
- *                 metadata?: array<string, mixed>,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             metadata?: array<string, mixed>,
+ *             metadata?: list<mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
- *         resource?: scalar|Param|null,
- *         type?: scalar|Param|null,
- *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|Param|null, // Default: 80
- *         https_port?: scalar|Param|null, // Default: 443
- *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         resource: scalar|null|Param,
+ *         type?: scalar|null|Param,
+ *         default_uri?: scalar|null|Param, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|null|Param, // Default: 80
+ *         https_port?: scalar|null|Param, // Default: 443
+ *         strict_requirements?: scalar|null|Param, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
  *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
  *         enabled?: bool|Param, // Default: false
- *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|Param|null,
- *         cookie_lifetime?: scalar|Param|null,
- *         cookie_path?: scalar|Param|null,
- *         cookie_domain?: scalar|Param|null,
+ *         storage_factory_id?: scalar|null|Param, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|null|Param, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|null|Param,
+ *         cookie_lifetime?: scalar|null|Param,
+ *         cookie_path?: scalar|null|Param,
+ *         cookie_domain?: scalar|null|Param,
  *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
  *         cookie_httponly?: bool|Param, // Default: true
  *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
  *         use_cookies?: bool|Param,
- *         gc_divisor?: scalar|Param|null,
- *         gc_probability?: scalar|Param|null,
- *         gc_maxlifetime?: scalar|Param|null,
- *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         gc_divisor?: scalar|null|Param,
+ *         gc_probability?: scalar|null|Param,
+ *         gc_maxlifetime?: scalar|null|Param,
+ *         save_path?: scalar|null|Param, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
  *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
- *         formats?: array<string, string|list<scalar|Param|null>>,
+ *         formats?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
  *         enabled?: bool|Param, // Default: true
  *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|Param|null, // Default: null
- *         version?: scalar|Param|null, // Default: null
- *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|Param|null, // Default: null
- *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: string|list<scalar|Param|null>,
+ *         version_strategy?: scalar|null|Param, // Default: null
+ *         version?: scalar|null|Param, // Default: null
+ *         version_format?: scalar|null|Param, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|null|Param, // Default: null
+ *         base_path?: scalar|null|Param, // Default: ""
+ *         base_urls?: list<scalar|null|Param>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|Param|null, // Default: null
- *             version?: scalar|Param|null,
- *             version_format?: scalar|Param|null, // Default: null
- *             json_manifest_path?: scalar|Param|null, // Default: null
- *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: string|list<scalar|Param|null>,
+ *             version_strategy?: scalar|null|Param, // Default: null
+ *             version?: scalar|null|Param,
+ *             version_format?: scalar|null|Param, // Default: null
+ *             json_manifest_path?: scalar|null|Param, // Default: null
+ *             base_path?: scalar|null|Param, // Default: ""
+ *             base_urls?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: true
- *         paths?: string|array<string, scalar|Param|null>,
- *         excluded_patterns?: list<scalar|Param|null>,
+ *         paths?: array<string, scalar|null|Param>,
+ *         excluded_patterns?: list<scalar|null|Param>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         public_prefix?: scalar|null|Param, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
  *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|Param|null>,
- *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|Param|null>,
- *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         extensions?: array<string, scalar|null|Param>,
+ *         importmap_path?: scalar|null|Param, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|null|Param, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|null|Param>,
+ *         vendor_dir?: scalar|null|Param, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
  *             enabled?: bool|Param, // Default: false
- *             formats?: list<scalar|Param|null>,
- *             extensions?: list<scalar|Param|null>,
+ *             formats?: list<scalar|null|Param>,
+ *             extensions?: list<scalar|null|Param>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: true
- *         fallbacks?: string|list<scalar|Param|null>,
+ *         fallbacks?: list<scalar|null|Param>,
  *         logging?: bool|Param, // Default: false
- *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|Param|null>,
+ *         formatter?: scalar|null|Param, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|null|Param, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|null|Param>,
  *         pseudo_localization?: bool|array{
  *             enabled?: bool|Param, // Default: false
  *             accents?: bool|Param, // Default: true
  *             expansion_factor?: float|Param, // Default: 1.0
  *             brackets?: bool|Param, // Default: true
  *             parse_html?: bool|Param, // Default: false
- *             localizable_html_attributes?: list<scalar|Param|null>,
+ *             localizable_html_attributes?: list<scalar|null|Param>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             domains?: list<scalar|Param|null>,
- *             locales?: list<scalar|Param|null>,
+ *             dsn?: scalar|null|Param,
+ *             domains?: list<scalar|null|Param>,
+ *             locales?: list<scalar|null|Param>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *             message?: string|Param,
- *             parameters?: array<string, scalar|Param|null>,
+ *             parameters?: array<string, scalar|null|Param>,
  *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: string|list<scalar|Param|null>,
- *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         static_method?: list<scalar|null|Param>,
+ *         translation_domain?: scalar|null|Param, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
  *         not_compromised_password?: bool|array{
  *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             endpoint?: scalar|null|Param, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
  *         disable_translation?: bool|Param, // Default: false
- *         property_metadata_existence_check?: bool|Param, // When enabled, validateProperty() and validatePropertyValue() throw an exception if no metadata is found for the given property. // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|Param|null>,
+ *             services?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         name_converter?: scalar|Param|null,
- *         circular_reference_handler?: scalar|Param|null,
- *         max_depth_handler?: scalar|Param|null,
+ *         name_converter?: scalar|null|Param,
+ *         circular_reference_handler?: scalar|null|Param,
+ *         max_depth_handler?: scalar|null|Param,
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
- *         default_context?: array<string, mixed>,
+ *         default_context?: list<mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|Param|null,
- *             default_context?: array<string, mixed>,
+ *             name_converter?: scalar|null|Param,
+ *             default_context?: list<mixed>,
  *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
  *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
@@ -378,32 +371,31 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     type_info?: bool|array{ // Type info configuration
  *         enabled?: bool|Param, // Default: true
- *         aliases?: array<string, scalar|Param|null>,
+ *         aliases?: array<string, scalar|null|Param>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
  *         enabled?: bool|Param, // Default: true
  *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|Param|null,
- *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
- *         default_pdo_provider?: scalar|Param|null, // Default: null
+ *         prefix_seed?: scalar|null|Param, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|null|Param, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|null|Param, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|null|Param, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|null|Param,
+ *         default_redis_provider?: scalar|null|Param, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|null|Param, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|null|Param, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|null|Param, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|null|Param, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: string|list<scalar|Param|null>,
- *             tags?: scalar|Param|null, // Default: null
+ *             adapters?: list<scalar|null|Param>,
+ *             tags?: scalar|null|Param, // Default: null
  *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
- *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|Param|null,
- *             clearer?: scalar|Param|null,
- *             marshaller?: scalar|Param|null, // The marshaller service to use for this pool.
+ *             default_lifetime?: scalar|null|Param, // Default lifetime of the pool.
+ *             provider?: scalar|null|Param, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|null|Param,
+ *             clearer?: scalar|null|Param,
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
@@ -411,57 +403,59 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|null|Param, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|null|Param, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|null|Param, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: true
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, string|list<scalar|Param|null>>,
+ *         resources?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: string|array<string, scalar|Param|null>,
+ *         resources?: array<string, scalar|null|Param>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: false
- *         routing?: array<string, string|list<scalar|Param|null>>,
+ *         routing?: array<string, array{ // Default: []
+ *             senders?: list<scalar|null|Param>,
+ *         }>,
  *         serializer?: array{
- *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|null|Param, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|null|Param, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
- *             options?: array<string, mixed>,
- *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             dsn?: scalar|null|Param,
+ *             serializer?: scalar|null|Param, // Service id of a custom serializer to use. // Default: null
+ *             options?: list<mixed>,
+ *             failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 service?: scalar|null|Param, // Service id to override the retry strategy entirely. // Default: null
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
  *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
  *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
- *         default_bus?: scalar|Param|null, // Default: null
+ *         failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|null|Param>,
+ *         default_bus?: scalar|null|Param, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
  *                 enabled?: bool|Param, // Default: true
  *                 allow_no_handlers?: bool|Param, // Default: false
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: string|list<string|array{ // Default: []
- *                 id?: scalar|Param|null,
+ *             middleware?: list<string|array{ // Default: []
+ *                 id: scalar|null|Param,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
@@ -477,41 +471,41 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -520,52 +514,51 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, or the id of the service to use to generate mock responses - which should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|null|Param, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|Param|null>,
+ *             scope?: scalar|null|Param, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|null|Param, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|null|Param, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|null|Param, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|null|Param, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|null|Param>,
  *             headers?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
- *             mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable).
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: int|string|array<string, array{ // Default: []
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: string|list<string|Param>,
+ *                     methods?: list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -577,117 +570,110 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|Param|null, // Default: null
- *         transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|null|Param, // Default: null
+ *         transports?: array<string, scalar|null|Param>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|Param|null,
- *             recipients?: string|list<scalar|Param|null>,
- *             allowed_recipients?: string|list<scalar|Param|null>,
+ *             sender?: scalar|null|Param,
+ *             recipients?: list<scalar|null|Param>,
+ *             allowed_recipients?: list<scalar|null|Param>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|Param|null, // Default: ""
- *             select?: scalar|Param|null, // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
+ *             key?: scalar|null|Param, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|null|Param, // Default: ""
+ *             select?: scalar|null|Param, // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|Param|null, // Default: null
+ *             key?: scalar|null|Param, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|null|Param, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|null|Param, // Default: null
  *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
  *             enabled?: bool|Param, // Default: false
- *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             repository?: scalar|null|Param, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
  *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
  *         enabled?: bool|Param, // Default: true
- *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
- *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         vault_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|null|Param, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
+ *         decryption_env_var?: scalar|null|Param, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
  *         enabled?: bool|Param, // Default: true
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|Param|null>,
- *         texter_transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|null|Param>,
+ *         texter_transports?: array<string, scalar|null|Param>,
  *         notification_on_failed_messages?: bool|Param, // Default: false
- *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         channel_policy?: array<string, string|list<scalar|null|Param>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|Param|null,
- *             phone?: scalar|Param|null, // Default: ""
+ *             email?: scalar|null|Param,
+ *             phone?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: false
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: string|list<scalar|Param|null>,
+ *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|null|Param, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|null|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|null|Param>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             interval?: scalar|null|Param, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 interval?: scalar|null|Param, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
- *             anchor_at?: scalar|Param|null, // Aligns the "fixed_window" policy to a calendar (e.g. "2024-01-05 00:00:00 UTC" combined with `interval: 1 month` resets the counter on the 5th of each month). UTC if not specified. // Default: null
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
  *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
- *         name_based_uuid_namespace?: scalar|Param|null,
+ *         name_based_uuid_namespace?: scalar|null|Param,
  *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
- *         time_based_uuid_node?: scalar|Param|null,
- *         uuid47_secret?: scalar|Param|null, // A high-entropy secret used by the "uuid47_transformer" service. Defaults to "kernel.secret". // Default: null
+ *         time_based_uuid_node?: scalar|null|Param,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
- *             default_action?: "drop"|"block"|"allow"|Param, // Defines how the sanitizer must behave by default.
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: string|list<string|Param>,
- *             drop_elements?: string|list<string|Param>,
+ *             block_elements?: list<string|Param>,
+ *             drop_elements?: list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
  *             force_attributes?: array<string, array<string, string|Param>>,
  *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: string|list<string|Param>,
- *             allowed_link_hosts?: null|string|list<string|Param>,
+ *             allowed_link_schemes?: list<string|Param>,
+ *             allowed_link_hosts?: list<string|Param>|null,
  *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: string|list<string|Param>,
- *             allowed_media_hosts?: null|string|list<string|Param>,
+ *             allowed_media_schemes?: list<string|Param>,
+ *             allowed_media_hosts?: list<string|Param>|null,
  *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: string|list<string|Param>,
- *             without_attribute_sanitizers?: string|list<string|Param>,
+ *             with_attribute_sanitizers?: list<string|Param>,
+ *             without_attribute_sanitizers?: list<string|Param>,
  *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
- *         event_header_name?: scalar|Param|null, // Default: "Webhook-Event"
- *         id_header_name?: scalar|Param|null, // Default: "Webhook-Id"
- *         signature_header_name?: scalar|Param|null, // Default: "Webhook-Signature"
- *         signing_algorithm?: scalar|Param|null, // Default: "sha256"
+ *         message_bus?: scalar|null|Param, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service?: scalar|Param|null,
- *             secret?: scalar|Param|null, // Default: ""
+ *             service: scalar|null|Param,
+ *             secret?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
@@ -695,42 +681,38 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     json_streamer?: bool|array{ // JSON streamer configuration
  *         enabled?: bool|Param, // Default: false
- *         default_options?: array{
- *             include_null_properties?: bool|Param, // Encode the properties with null value // Default: false
- *             ...<string, mixed>
- *         },
  *     },
  * }
  * @psalm-type TwigConfig = array{
- *     form_themes?: list<scalar|Param|null>,
+ *     form_themes?: list<scalar|null|Param>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|Param|null,
- *         type?: scalar|Param|null,
+ *         id?: scalar|null|Param,
+ *         type?: scalar|null|Param,
  *         value?: mixed,
  *     }>,
- *     autoescape_service?: scalar|Param|null, // Default: null
- *     autoescape_service_method?: scalar|Param|null, // Default: null
- *     cache?: scalar|Param|null, // Default: true
- *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
+ *     autoescape_service?: scalar|null|Param, // Default: null
+ *     autoescape_service_method?: scalar|null|Param, // Default: null
+ *     cache?: scalar|null|Param, // Default: true
+ *     charset?: scalar|null|Param, // Default: "%kernel.charset%"
  *     debug?: bool|Param, // Default: "%kernel.debug%"
  *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
- *     auto_reload?: scalar|Param|null,
+ *     auto_reload?: scalar|null|Param,
  *     optimizations?: int|Param,
- *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: string|list<scalar|Param|null>,
+ *     default_path?: scalar|null|Param, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: list<scalar|null|Param>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
- *         format?: scalar|Param|null, // Default: "F j, Y H:i"
- *         interval_format?: scalar|Param|null, // Default: "%d days"
- *         timezone?: scalar|Param|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *         format?: scalar|null|Param, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|null|Param, // Default: "%d days"
+ *         timezone?: scalar|null|Param, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
  *     },
  *     number_format?: array{ // The default format options for the number_format filter.
  *         decimals?: int|Param, // Default: 0
- *         decimal_point?: scalar|Param|null, // Default: "."
- *         thousands_separator?: scalar|Param|null, // Default: ","
+ *         decimal_point?: scalar|null|Param, // Default: "."
+ *         thousands_separator?: scalar|null|Param, // Default: ","
  *     },
  *     mailer?: array{
- *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *         html_to_text_converter?: scalar|null|Param, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
  *     },
  * }
  * @psalm-type TwigExtraConfig = array{
@@ -757,9 +739,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     commonmark?: array{
  *         renderer?: array{ // Array of options for rendering HTML.
- *             block_separator?: scalar|Param|null,
- *             inner_separator?: scalar|Param|null,
- *             soft_break?: scalar|Param|null,
+ *             block_separator?: scalar|null|Param,
+ *             inner_separator?: scalar|null|Param,
+ *             soft_break?: scalar|null|Param,
  *         },
  *         html_input?: "strip"|"allow"|"escape"|Param, // How to handle HTML input.
  *         allow_unsafe_links?: bool|Param, // Remove risky link and image URLs by setting this to false. // Default: true
@@ -775,39 +757,39 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             enable_strong?: bool|Param, // Default: true
  *             use_asterisk?: bool|Param, // Default: true
  *             use_underscore?: bool|Param, // Default: true
- *             unordered_list_markers?: list<scalar|Param|null>,
+ *             unordered_list_markers?: list<scalar|null|Param>,
  *         },
- *         ...<string, mixed>
+ *         ...<mixed>
  *     },
  * }
  * @psalm-type TurboConfig = array{
  *     broadcast?: bool|array{
  *         enabled?: bool|Param, // Default: true
- *         entity_template_prefixes?: list<scalar|Param|null>,
+ *         entity_template_prefixes?: list<scalar|null|Param>,
  *         doctrine_orm?: bool|array{ // Enable the Doctrine ORM integration
  *             enabled?: bool|Param, // Default: true
  *         },
  *     },
- *     default_transport?: scalar|Param|null, // Default: "default"
+ *     default_transport?: scalar|null|Param, // Default: "default"
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|null|Param, // URL of the hub's publish endpoint
+ *         public_url?: scalar|null|Param, // URL of the hub's public endpoint // Default: null
  *         jwt?: string|array{ // JSON Web Token configuration.
- *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
- *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.
- *             factory?: scalar|Param|null, // The ID of a service to call to create the JSON Web Token.
- *             publish?: list<scalar|Param|null>,
- *             subscribe?: list<scalar|Param|null>,
- *             secret?: scalar|Param|null, // The JWT Secret to use.
- *             passphrase?: scalar|Param|null, // The JWT secret passphrase. // Default: ""
- *             algorithm?: scalar|Param|null, // The algorithm to use to sign the JWT // Default: "hmac.sha256"
+ *             value?: scalar|null|Param, // JSON Web Token to use to publish to this hub.
+ *             provider?: scalar|null|Param, // The ID of a service to call to provide the JSON Web Token.
+ *             factory?: scalar|null|Param, // The ID of a service to call to create the JSON Web Token.
+ *             publish?: list<scalar|null|Param>,
+ *             subscribe?: list<scalar|null|Param>,
+ *             secret?: scalar|null|Param, // The JWT Secret to use.
+ *             passphrase?: scalar|null|Param, // The JWT secret passphrase. // Default: ""
+ *             algorithm?: scalar|null|Param, // The algorithm to use to sign the JWT // Default: "hmac.sha256"
  *         },
- *         jwt_provider?: scalar|Param|null, // Deprecated: The child node "jwt_provider" at path "mercure.hubs..jwt_provider" is deprecated, use "jwt.provider" instead. // The ID of a service to call to generate the JSON Web Token.
- *         bus?: scalar|Param|null, // Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.
+ *         jwt_provider?: scalar|null|Param, // Deprecated: The child node "jwt_provider" at path "mercure.hubs..jwt_provider" is deprecated, use "jwt.provider" instead. // The ID of a service to call to generate the JSON Web Token.
+ *         bus?: scalar|null|Param, // Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled.
  *     }>,
- *     default_hub?: scalar|Param|null,
+ *     default_hub?: scalar|null|Param,
  *     default_cookie_lifetime?: int|Param, // Default lifetime of the cookie containing the JWT, in seconds. Defaults to the value of "framework.session.cookie_lifetime". // Default: null
  *     enable_profiler?: bool|Param, // Deprecated: The child node "enable_profiler" at path "mercure.enable_profiler" is deprecated. // Enable Symfony Web Profiler integration.
  * }
@@ -817,148 +799,148 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         ajax_replace?: bool|Param, // Replace toolbar on AJAX requests // Default: false
  *     },
  *     intercept_redirects?: bool|Param, // Default: false
- *     excluded_ajax_paths?: scalar|Param|null, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
+ *     excluded_ajax_paths?: scalar|null|Param, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
  * }
  * @psalm-type MonologConfig = array{
- *     use_microseconds?: scalar|Param|null, // Default: true
- *     channels?: list<scalar|Param|null>,
+ *     use_microseconds?: scalar|null|Param, // Default: true
+ *     channels?: list<scalar|null|Param>,
  *     handlers?: array<string, array{ // Default: []
- *         type?: scalar|Param|null,
- *         id?: scalar|Param|null,
+ *         type: scalar|null|Param,
+ *         id?: scalar|null|Param,
  *         enabled?: bool|Param, // Default: true
- *         priority?: scalar|Param|null, // Default: 0
- *         level?: scalar|Param|null, // Default: "DEBUG"
+ *         priority?: scalar|null|Param, // Default: 0
+ *         level?: scalar|null|Param, // Default: "DEBUG"
  *         bubble?: bool|Param, // Default: true
  *         interactive_only?: bool|Param, // Default: false
- *         app_name?: scalar|Param|null, // Default: null
+ *         app_name?: scalar|null|Param, // Default: null
  *         include_stacktraces?: bool|Param, // Default: false
  *         process_psr_3_messages?: array{
- *             enabled?: bool|Param|null, // Default: null
- *             date_format?: scalar|Param|null,
+ *             enabled?: bool|null|Param, // Default: null
+ *             date_format?: scalar|null|Param,
  *             remove_used_context_fields?: bool|Param,
  *         },
- *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|Param|null, // Default: null
+ *         path?: scalar|null|Param, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *         file_permission?: scalar|null|Param, // Default: null
  *         use_locking?: bool|Param, // Default: false
- *         filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
- *         date_format?: scalar|Param|null, // Default: "Y-m-d"
- *         ident?: scalar|Param|null, // Default: false
- *         logopts?: scalar|Param|null, // Default: 1
- *         facility?: scalar|Param|null, // Default: "user"
- *         max_files?: scalar|Param|null, // Default: 0
- *         action_level?: scalar|Param|null, // Default: "WARNING"
- *         activation_strategy?: scalar|Param|null, // Default: null
+ *         filename_format?: scalar|null|Param, // Default: "{filename}-{date}"
+ *         date_format?: scalar|null|Param, // Default: "Y-m-d"
+ *         ident?: scalar|null|Param, // Default: false
+ *         logopts?: scalar|null|Param, // Default: 1
+ *         facility?: scalar|null|Param, // Default: "user"
+ *         max_files?: scalar|null|Param, // Default: 0
+ *         action_level?: scalar|null|Param, // Default: "WARNING"
+ *         activation_strategy?: scalar|null|Param, // Default: null
  *         stop_buffering?: bool|Param, // Default: true
- *         passthru_level?: scalar|Param|null, // Default: null
+ *         passthru_level?: scalar|null|Param, // Default: null
  *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|Param|null,
- *             urls?: list<scalar|Param|null>,
+ *             code?: scalar|null|Param,
+ *             urls?: list<scalar|null|Param>,
  *         }>,
- *         accepted_levels?: list<scalar|Param|null>,
- *         min_level?: scalar|Param|null, // Default: "DEBUG"
- *         max_level?: scalar|Param|null, // Default: "EMERGENCY"
- *         buffer_size?: scalar|Param|null, // Default: 0
+ *         accepted_levels?: list<scalar|null|Param>,
+ *         min_level?: scalar|null|Param, // Default: "DEBUG"
+ *         max_level?: scalar|null|Param, // Default: "EMERGENCY"
+ *         buffer_size?: scalar|null|Param, // Default: 0
  *         flush_on_overflow?: bool|Param, // Default: false
- *         handler?: scalar|Param|null,
- *         url?: scalar|Param|null,
- *         exchange?: scalar|Param|null,
- *         exchange_name?: scalar|Param|null, // Default: "log"
- *         channel?: scalar|Param|null, // Default: null
- *         bot_name?: scalar|Param|null, // Default: "Monolog"
- *         use_attachment?: scalar|Param|null, // Default: true
- *         use_short_attachment?: scalar|Param|null, // Default: false
- *         include_extra?: scalar|Param|null, // Default: false
- *         icon_emoji?: scalar|Param|null, // Default: null
- *         webhook_url?: scalar|Param|null,
- *         exclude_fields?: list<scalar|Param|null>,
- *         token?: scalar|Param|null,
- *         region?: scalar|Param|null,
- *         source?: scalar|Param|null,
+ *         handler?: scalar|null|Param,
+ *         url?: scalar|null|Param,
+ *         exchange?: scalar|null|Param,
+ *         exchange_name?: scalar|null|Param, // Default: "log"
+ *         channel?: scalar|null|Param, // Default: null
+ *         bot_name?: scalar|null|Param, // Default: "Monolog"
+ *         use_attachment?: scalar|null|Param, // Default: true
+ *         use_short_attachment?: scalar|null|Param, // Default: false
+ *         include_extra?: scalar|null|Param, // Default: false
+ *         icon_emoji?: scalar|null|Param, // Default: null
+ *         webhook_url?: scalar|null|Param,
+ *         exclude_fields?: list<scalar|null|Param>,
+ *         token?: scalar|null|Param,
+ *         region?: scalar|null|Param,
+ *         source?: scalar|null|Param,
  *         use_ssl?: bool|Param, // Default: true
  *         user?: mixed,
- *         title?: scalar|Param|null, // Default: null
- *         host?: scalar|Param|null, // Default: null
- *         port?: scalar|Param|null, // Default: 514
- *         config?: list<scalar|Param|null>,
- *         members?: list<scalar|Param|null>,
- *         connection_string?: scalar|Param|null,
- *         timeout?: scalar|Param|null,
- *         time?: scalar|Param|null, // Default: 60
- *         deduplication_level?: scalar|Param|null, // Default: 400
- *         store?: scalar|Param|null, // Default: null
- *         connection_timeout?: scalar|Param|null,
+ *         title?: scalar|null|Param, // Default: null
+ *         host?: scalar|null|Param, // Default: null
+ *         port?: scalar|null|Param, // Default: 514
+ *         config?: list<scalar|null|Param>,
+ *         members?: list<scalar|null|Param>,
+ *         connection_string?: scalar|null|Param,
+ *         timeout?: scalar|null|Param,
+ *         time?: scalar|null|Param, // Default: 60
+ *         deduplication_level?: scalar|null|Param, // Default: 400
+ *         store?: scalar|null|Param, // Default: null
+ *         connection_timeout?: scalar|null|Param,
  *         persistent?: bool|Param,
- *         message_type?: scalar|Param|null, // Default: 0
- *         parse_mode?: scalar|Param|null, // Default: null
- *         disable_webpage_preview?: bool|Param|null, // Default: null
- *         disable_notification?: bool|Param|null, // Default: null
+ *         message_type?: scalar|null|Param, // Default: 0
+ *         parse_mode?: scalar|null|Param, // Default: null
+ *         disable_webpage_preview?: bool|null|Param, // Default: null
+ *         disable_notification?: bool|null|Param, // Default: null
  *         split_long_messages?: bool|Param, // Default: false
  *         delay_between_messages?: bool|Param, // Default: false
  *         topic?: int|Param, // Default: null
  *         factor?: int|Param, // Default: 1
- *         tags?: string|list<scalar|Param|null>,
+ *         tags?: list<scalar|null|Param>,
  *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|Param|null,
+ *         formatter?: scalar|null|Param,
  *         nested?: bool|Param, // Default: false
  *         publisher?: string|array{
- *             id?: scalar|Param|null,
- *             hostname?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 12201
- *             chunk_size?: scalar|Param|null, // Default: 1420
+ *             id?: scalar|null|Param,
+ *             hostname?: scalar|null|Param,
+ *             port?: scalar|null|Param, // Default: 12201
+ *             chunk_size?: scalar|null|Param, // Default: 1420
  *             encoder?: "json"|"compressed_json"|Param,
  *         },
  *         mongodb?: string|array{
- *             id?: scalar|Param|null, // ID of a MongoDB\Client service
- *             uri?: scalar|Param|null,
- *             username?: scalar|Param|null,
- *             password?: scalar|Param|null,
- *             database?: scalar|Param|null, // Default: "monolog"
- *             collection?: scalar|Param|null, // Default: "logs"
+ *             id?: scalar|null|Param, // ID of a MongoDB\Client service
+ *             uri?: scalar|null|Param,
+ *             username?: scalar|null|Param,
+ *             password?: scalar|null|Param,
+ *             database?: scalar|null|Param, // Default: "monolog"
+ *             collection?: scalar|null|Param, // Default: "logs"
  *         },
  *         elasticsearch?: string|array{
- *             id?: scalar|Param|null,
- *             hosts?: list<scalar|Param|null>,
- *             host?: scalar|Param|null,
- *             port?: scalar|Param|null, // Default: 9200
- *             transport?: scalar|Param|null, // Default: "Http"
- *             user?: scalar|Param|null, // Default: null
- *             password?: scalar|Param|null, // Default: null
+ *             id?: scalar|null|Param,
+ *             hosts?: list<scalar|null|Param>,
+ *             host?: scalar|null|Param,
+ *             port?: scalar|null|Param, // Default: 9200
+ *             transport?: scalar|null|Param, // Default: "Http"
+ *             user?: scalar|null|Param, // Default: null
+ *             password?: scalar|null|Param, // Default: null
  *         },
- *         index?: scalar|Param|null, // Default: "monolog"
- *         document_type?: scalar|Param|null, // Default: "logs"
- *         ignore_error?: scalar|Param|null, // Default: false
+ *         index?: scalar|null|Param, // Default: "monolog"
+ *         document_type?: scalar|null|Param, // Default: "logs"
+ *         ignore_error?: scalar|null|Param, // Default: false
  *         redis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
- *             password?: scalar|Param|null, // Default: null
- *             port?: scalar|Param|null, // Default: 6379
- *             database?: scalar|Param|null, // Default: 0
- *             key_name?: scalar|Param|null, // Default: "monolog_redis"
+ *             id?: scalar|null|Param,
+ *             host?: scalar|null|Param,
+ *             password?: scalar|null|Param, // Default: null
+ *             port?: scalar|null|Param, // Default: 6379
+ *             database?: scalar|null|Param, // Default: 0
+ *             key_name?: scalar|null|Param, // Default: "monolog_redis"
  *         },
  *         predis?: string|array{
- *             id?: scalar|Param|null,
- *             host?: scalar|Param|null,
+ *             id?: scalar|null|Param,
+ *             host?: scalar|null|Param,
  *         },
- *         from_email?: scalar|Param|null,
- *         to_email?: string|list<scalar|Param|null>,
- *         subject?: scalar|Param|null,
- *         content_type?: scalar|Param|null, // Default: null
- *         headers?: list<scalar|Param|null>,
- *         mailer?: scalar|Param|null, // Default: null
+ *         from_email?: scalar|null|Param,
+ *         to_email?: list<scalar|null|Param>,
+ *         subject?: scalar|null|Param,
+ *         content_type?: scalar|null|Param, // Default: null
+ *         headers?: list<scalar|null|Param>,
+ *         mailer?: scalar|null|Param, // Default: null
  *         email_prototype?: string|array{
- *             id?: scalar|Param|null,
- *             method?: scalar|Param|null, // Default: null
+ *             id: scalar|null|Param,
+ *             method?: scalar|null|Param, // Default: null
  *         },
  *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
+ *             VERBOSITY_QUIET?: scalar|null|Param, // Default: "ERROR"
+ *             VERBOSITY_NORMAL?: scalar|null|Param, // Default: "WARNING"
+ *             VERBOSITY_VERBOSE?: scalar|null|Param, // Default: "NOTICE"
+ *             VERBOSITY_VERY_VERBOSE?: scalar|null|Param, // Default: "INFO"
+ *             VERBOSITY_DEBUG?: scalar|null|Param, // Default: "DEBUG"
  *         },
  *         channels?: string|array{
- *             type?: scalar|Param|null,
- *             elements?: list<scalar|Param|null>,
+ *             type?: scalar|null|Param,
+ *             elements?: list<scalar|null|Param>,
  *         },
  *     }>,
  * }
@@ -966,111 +948,111 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     max_items?: int|Param, // Max number of displayed items past the first level, -1 means no limit. // Default: 2500
  *     min_depth?: int|Param, // Minimum tree depth to clone all the items, 1 is default. // Default: 1
  *     max_string_length?: int|Param, // Max length of displayed strings, -1 means no limit. // Default: -1
- *     dump_destination?: scalar|Param|null, // A stream URL where dumps should be written to. // Default: null
+ *     dump_destination?: scalar|null|Param, // A stream URL where dumps should be written to. // Default: null
  *     theme?: "dark"|"light"|Param, // Changes the color of the dump() output when rendered directly on the templating. "dark" (default) or "light". // Default: "dark"
  * }
  * @psalm-type TwigComponentConfig = array{
- *     defaults?: array<string, string|array{ // Default: []
- *         template_directory?: scalar|Param|null, // Default: "components"
- *         name_prefix?: scalar|Param|null, // Default: ""
+ *     defaults: array<string, string|array{ // Default: []
+ *         template_directory?: scalar|null|Param, // Default: "components"
+ *         name_prefix?: scalar|null|Param, // Default: ""
  *     }>,
- *     anonymous_template_directory?: scalar|Param|null, // Defaults to `components`
+ *     anonymous_template_directory: scalar|null|Param, // Defaults to `components`
  *     profiler?: bool|array{ // Enables the profiler for Twig Component
  *         enabled?: bool|Param, // Default: "%kernel.debug%"
  *         collect_components?: bool|Param, // Collect components instances // Default: true
  *     },
  * }
  * @psalm-type LiveComponentConfig = array{
- *     secret?: scalar|Param|null, // The secret used to compute fingerprints and checksums // Default: "%kernel.secret%"
+ *     secret?: scalar|null|Param, // The secret used to compute fingerprints and checksums // Default: "%kernel.secret%"
  *     fetch_credentials?: "same-origin"|"include"|"omit"|Param, // The default fetch credentials mode for all Live Components ('same-origin', 'include', 'omit') // Default: "same-origin"
  * }
  * @psalm-type DoctrineConfig = array{
  *     dbal?: array{
- *         default_connection?: scalar|Param|null,
+ *         default_connection?: scalar|null|Param,
  *         types?: array<string, string|array{ // Default: []
- *             class?: scalar|Param|null,
+ *             class: scalar|null|Param,
  *         }>,
- *         driver_schemes?: array<string, scalar|Param|null>,
+ *         driver_schemes?: array<string, scalar|null|Param>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|Param|null,
- *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
- *             port?: scalar|Param|null, // Defaults to null at runtime.
- *             user?: scalar|Param|null, // Defaults to "root" at runtime.
- *             password?: scalar|Param|null, // Defaults to null at runtime.
- *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|Param|null,
- *             charset?: scalar|Param|null,
- *             path?: scalar|Param|null,
+ *             url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *             dbname?: scalar|null|Param,
+ *             host?: scalar|null|Param, // Defaults to "localhost" at runtime.
+ *             port?: scalar|null|Param, // Defaults to null at runtime.
+ *             user?: scalar|null|Param, // Defaults to "root" at runtime.
+ *             password?: scalar|null|Param, // Defaults to null at runtime.
+ *             dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *             application_name?: scalar|null|Param,
+ *             charset?: scalar|null|Param,
+ *             path?: scalar|null|Param,
  *             memory?: bool|Param,
- *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *             unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
  *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *             protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
  *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
- *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *             servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *             sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
+ *             server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
+ *             default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *             sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *             sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
+ *             sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
+ *             sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
  *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
  *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|Param|null, // Default: "pdo_mysql"
+ *             instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *             connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             driver?: scalar|null|Param, // Default: "pdo_mysql"
  *             auto_commit?: bool|Param,
- *             schema_filter?: scalar|Param|null,
+ *             schema_filter?: scalar|null|Param,
  *             logging?: bool|Param, // Default: true
  *             profiling?: bool|Param, // Default: true
  *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
  *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
- *             server_version?: scalar|Param|null,
+ *             server_version?: scalar|null|Param,
  *             idle_connection_ttl?: int|Param, // Default: 600
- *             driver_class?: scalar|Param|null,
- *             wrapper_class?: scalar|Param|null,
+ *             driver_class?: scalar|null|Param,
+ *             wrapper_class?: scalar|null|Param,
  *             keep_replica?: bool|Param,
  *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|Param|null>,
- *             default_table_options?: array<string, scalar|Param|null>,
- *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
- *             result_cache?: scalar|Param|null,
+ *             mapping_types?: array<string, scalar|null|Param>,
+ *             default_table_options?: array<string, scalar|null|Param>,
+ *             schema_manager_factory?: scalar|null|Param, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *             result_cache?: scalar|null|Param,
  *             replicas?: array<string, array{ // Default: []
- *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|Param|null,
- *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
- *                 port?: scalar|Param|null, // Defaults to null at runtime.
- *                 user?: scalar|Param|null, // Defaults to "root" at runtime.
- *                 password?: scalar|Param|null, // Defaults to null at runtime.
- *                 dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|Param|null,
- *                 charset?: scalar|Param|null,
- *                 path?: scalar|Param|null,
+ *                 url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|null|Param,
+ *                 host?: scalar|null|Param, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|null|Param, // Defaults to null at runtime.
+ *                 user?: scalar|null|Param, // Defaults to "root" at runtime.
+ *                 password?: scalar|null|Param, // Defaults to null at runtime.
+ *                 dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|null|Param,
+ *                 charset?: scalar|null|Param,
+ *                 path?: scalar|null|Param,
  *                 memory?: bool|Param,
- *                 unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
+ *                 unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
  *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
  *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
- *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
+ *                 server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
  *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
  *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
  *             }>,
  *         }>,
  *     },
  *     orm?: array{
- *         default_entity_manager?: scalar|Param|null,
+ *         default_entity_manager?: scalar|null|Param,
  *         enable_native_lazy_objects?: bool|Param, // Deprecated: The "enable_native_lazy_objects" option is deprecated and will be removed in DoctrineBundle 4.0, as native lazy objects are now always enabled. // Default: true
  *         controller_resolver?: bool|array{
  *             enabled?: bool|Param, // Default: true
@@ -1079,194 +1061,194 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         entity_managers?: array<string, array{ // Default: []
  *             query_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             metadata_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             result_cache_driver?: string|array{
- *                 type?: scalar|Param|null, // Default: null
- *                 id?: scalar|Param|null,
- *                 pool?: scalar|Param|null,
+ *                 type?: scalar|null|Param, // Default: null
+ *                 id?: scalar|null|Param,
+ *                 pool?: scalar|null|Param,
  *             },
  *             entity_listeners?: array{
  *                 entities?: array<string, array{ // Default: []
  *                     listeners?: array<string, array{ // Default: []
  *                         events?: list<array{ // Default: []
- *                             type?: scalar|Param|null,
- *                             method?: scalar|Param|null, // Default: null
+ *                             type?: scalar|null|Param,
+ *                             method?: scalar|null|Param, // Default: null
  *                         }>,
  *                     }>,
  *                 }>,
  *             },
- *             connection?: scalar|Param|null,
- *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|Param|null, // Default: false
- *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|Param|null, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|Param|null,
- *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|Param|null>,
+ *             connection?: scalar|null|Param,
+ *             class_metadata_factory_name?: scalar|null|Param, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *             default_repository_class?: scalar|null|Param, // Default: "Doctrine\\ORM\\EntityRepository"
+ *             auto_mapping?: scalar|null|Param, // Default: false
+ *             naming_strategy?: scalar|null|Param, // Default: "doctrine.orm.naming_strategy.default"
+ *             quote_strategy?: scalar|null|Param, // Default: "doctrine.orm.quote_strategy.default"
+ *             typed_field_mapper?: scalar|null|Param, // Default: "doctrine.orm.typed_field_mapper.default"
+ *             entity_listener_resolver?: scalar|null|Param, // Default: null
+ *             fetch_mode_subselect_batch_size?: scalar|null|Param,
+ *             repository_factory?: scalar|null|Param, // Default: "doctrine.orm.container_repository_factory"
+ *             schema_ignore_classes?: list<scalar|null|Param>,
  *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
  *             second_level_cache?: array{
  *                 region_cache_driver?: string|array{
- *                     type?: scalar|Param|null, // Default: null
- *                     id?: scalar|Param|null,
- *                     pool?: scalar|Param|null,
+ *                     type?: scalar|null|Param, // Default: null
+ *                     id?: scalar|null|Param,
+ *                     pool?: scalar|null|Param,
  *                 },
- *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
+ *                 region_lock_lifetime?: scalar|null|Param, // Default: 60
  *                 log_enabled?: bool|Param, // Default: true
- *                 region_lifetime?: scalar|Param|null, // Default: 3600
+ *                 region_lifetime?: scalar|null|Param, // Default: 3600
  *                 enabled?: bool|Param, // Default: true
- *                 factory?: scalar|Param|null,
+ *                 factory?: scalar|null|Param,
  *                 regions?: array<string, array{ // Default: []
  *                     cache_driver?: string|array{
- *                         type?: scalar|Param|null, // Default: null
- *                         id?: scalar|Param|null,
- *                         pool?: scalar|Param|null,
+ *                         type?: scalar|null|Param, // Default: null
+ *                         id?: scalar|null|Param,
+ *                         pool?: scalar|null|Param,
  *                     },
- *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|Param|null, // Default: 60
- *                     type?: scalar|Param|null, // Default: "default"
- *                     lifetime?: scalar|Param|null, // Default: 0
- *                     service?: scalar|Param|null,
- *                     name?: scalar|Param|null,
+ *                     lock_path?: scalar|null|Param, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                     lock_lifetime?: scalar|null|Param, // Default: 60
+ *                     type?: scalar|null|Param, // Default: "default"
+ *                     lifetime?: scalar|null|Param, // Default: 0
+ *                     service?: scalar|null|Param,
+ *                     name?: scalar|null|Param,
  *                 }>,
  *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|Param|null,
- *                     service?: scalar|Param|null,
+ *                     name?: scalar|null|Param,
+ *                     service?: scalar|null|Param,
  *                 }>,
  *             },
- *             hydrators?: array<string, scalar|Param|null>,
+ *             hydrators?: array<string, scalar|null|Param>,
  *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|Param|null, // Default: true
- *                 type?: scalar|Param|null,
- *                 dir?: scalar|Param|null,
- *                 alias?: scalar|Param|null,
- *                 prefix?: scalar|Param|null,
+ *                 mapping?: scalar|null|Param, // Default: true
+ *                 type?: scalar|null|Param,
+ *                 dir?: scalar|null|Param,
+ *                 alias?: scalar|null|Param,
+ *                 prefix?: scalar|null|Param,
  *                 is_bundle?: bool|Param,
  *             }>,
  *             dql?: array{
- *                 string_functions?: array<string, scalar|Param|null>,
- *                 numeric_functions?: array<string, scalar|Param|null>,
- *                 datetime_functions?: array<string, scalar|Param|null>,
+ *                 string_functions?: array<string, scalar|null|Param>,
+ *                 numeric_functions?: array<string, scalar|null|Param>,
+ *                 datetime_functions?: array<string, scalar|null|Param>,
  *             },
  *             filters?: array<string, string|array{ // Default: []
- *                 class?: scalar|Param|null,
+ *                 class: scalar|null|Param,
  *                 enabled?: bool|Param, // Default: false
  *                 parameters?: array<string, mixed>,
  *             }>,
- *             identity_generation_preferences?: array<string, scalar|Param|null>,
+ *             identity_generation_preferences?: array<string, scalar|null|Param>,
  *         }>,
- *         resolve_target_entities?: array<string, scalar|Param|null>,
+ *         resolve_target_entities?: array<string, scalar|null|Param>,
  *     },
  * }
  * @psalm-type DoctrineMigrationsConfig = array{
  *     enable_service_migrations?: bool|Param, // Whether to enable fetching migrations from the service container. // Default: false
- *     migrations_paths?: array<string, scalar|Param|null>,
- *     services?: array<string, scalar|Param|null>,
- *     factories?: array<string, scalar|Param|null>,
+ *     migrations_paths?: array<string, scalar|null|Param>,
+ *     services?: array<string, scalar|null|Param>,
+ *     factories?: array<string, scalar|null|Param>,
  *     storage?: array{ // Storage to use for migration status metadata.
  *         table_storage?: array{ // The default metadata storage, implemented as a table in the database.
- *             table_name?: scalar|Param|null, // Default: null
- *             version_column_name?: scalar|Param|null, // Default: null
- *             version_column_length?: scalar|Param|null, // Default: null
- *             executed_at_column_name?: scalar|Param|null, // Default: null
- *             execution_time_column_name?: scalar|Param|null, // Default: null
+ *             table_name?: scalar|null|Param, // Default: null
+ *             version_column_name?: scalar|null|Param, // Default: null
+ *             version_column_length?: scalar|null|Param, // Default: null
+ *             executed_at_column_name?: scalar|null|Param, // Default: null
+ *             execution_time_column_name?: scalar|null|Param, // Default: null
  *         },
  *     },
- *     migrations?: list<scalar|Param|null>,
- *     connection?: scalar|Param|null, // Connection name to use for the migrations database. // Default: null
- *     em?: scalar|Param|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
- *     all_or_nothing?: scalar|Param|null, // Run all migrations in a transaction. // Default: false
- *     check_database_platform?: scalar|Param|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
- *     custom_template?: scalar|Param|null, // Custom template path for generated migration classes. // Default: null
- *     organize_migrations?: scalar|Param|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
+ *     migrations?: list<scalar|null|Param>,
+ *     connection?: scalar|null|Param, // Connection name to use for the migrations database. // Default: null
+ *     em?: scalar|null|Param, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
+ *     all_or_nothing?: scalar|null|Param, // Run all migrations in a transaction. // Default: false
+ *     check_database_platform?: scalar|null|Param, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
+ *     custom_template?: scalar|null|Param, // Custom template path for generated migration classes. // Default: null
+ *     organize_migrations?: scalar|null|Param, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
  *     enable_profiler?: bool|Param, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
  *     transactional?: bool|Param, // Whether or not to wrap migrations in a single transaction. // Default: true
  * }
  * @psalm-type MakerConfig = array{
- *     root_namespace?: scalar|Param|null, // Default: "App"
+ *     root_namespace?: scalar|null|Param, // Default: "App"
  *     generate_final_classes?: bool|Param, // Default: true
  *     generate_final_entities?: bool|Param, // Default: false
  * }
  * @psalm-type NotifyConfig = array{
- *     mercure_hub?: scalar|Param|null, // Mercube hub service id // Default: "mercure.hub.default"
+ *     mercure_hub?: scalar|null|Param, // Mercube hub service id // Default: "mercure.hub.default"
  * }
  * @psalm-type ReactConfig = array{
- *     controllers_path?: scalar|Param|null, // The path to the directory where React controller components are stored - relevant only when using symfony/asset-mapper. // Default: "%kernel.project_dir%/assets/react/controllers"
- *     name_glob?: list<scalar|Param|null>,
+ *     controllers_path?: scalar|null|Param, // The path to the directory where React controller components are stored - relevant only when using symfony/asset-mapper. // Default: "%kernel.project_dir%/assets/react/controllers"
+ *     name_glob?: list<scalar|null|Param>,
  * }
  * @psalm-type VueConfig = array{
- *     controllers_path?: scalar|Param|null, // The path to the directory where Vue controller components are stored - relevant only when using symfony/asset-mapper. // Default: "%kernel.project_dir%/assets/vue/controllers"
- *     name_glob?: list<scalar|Param|null>,
+ *     controllers_path?: scalar|null|Param, // The path to the directory where Vue controller components are stored - relevant only when using symfony/asset-mapper. // Default: "%kernel.project_dir%/assets/vue/controllers"
+ *     name_glob?: list<scalar|null|Param>,
  * }
  * @psalm-type UxTranslatorConfig = array{
- *     dump_directory?: scalar|Param|null, // The directory where translations and TypeScript types are dumped. // Default: "%kernel.project_dir%/var/translations"
+ *     dump_directory?: scalar|null|Param, // The directory where translations and TypeScript types are dumped. // Default: "%kernel.project_dir%/var/translations"
  *     dump_typescript?: bool|Param, // Control whether TypeScript types are dumped alongside translations. Disable this if you do not use TypeScript (e.g. in production when using AssetMapper). // Default: true
  *     domains?: string|array{ // List of domains to include/exclude from the generated translations. Prefix with a `!` to exclude a domain.
- *         type?: scalar|Param|null,
- *         elements?: list<scalar|Param|null>,
+ *         type?: scalar|null|Param,
+ *         elements?: list<scalar|null|Param>,
  *     },
- *     keys_patterns?: string|list<scalar|Param|null>,
+ *     keys_patterns?: list<scalar|null|Param>,
  * }
  * @psalm-type StimulusConfig = array{
- *     controller_paths?: list<scalar|Param|null>,
- *     controllers_json?: scalar|Param|null, // Default: "%kernel.project_dir%/assets/controllers.json"
+ *     controller_paths?: list<scalar|null|Param>,
+ *     controllers_json?: scalar|null|Param, // Default: "%kernel.project_dir%/assets/controllers.json"
  * }
  * @psalm-type ZenstruckFoundryConfig = array{
- *     auto_refresh_proxies?: bool|Param|null, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null
- *     enable_auto_refresh_with_lazy_objects?: bool|Param|null, // Enable auto-refresh using PHP 8.4 lazy objects (cannot be enabled if PHP < 8.4). // Default: null
+ *     auto_refresh_proxies?: bool|null|Param, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null
+ *     enable_auto_refresh_with_lazy_objects?: bool|null|Param, // Enable auto-refresh using PHP 8.4 lazy objects (cannot be enabled if PHP < 8.4). // Default: null
  *     faker?: array{ // Configure the faker used by your factories.
- *         locale?: scalar|Param|null, // The default locale to use for faker. // Default: null
- *         seed?: scalar|Param|null, // Deprecated: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead. // Random number generator seed to produce the same fake values every run. // Default: null
- *         service?: scalar|Param|null, // Service id for custom faker instance. // Default: null
+ *         locale?: scalar|null|Param, // The default locale to use for faker. // Default: null
+ *         seed?: scalar|null|Param, // Deprecated: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead. // Random number generator seed to produce the same fake values every run. // Default: null
+ *         service?: scalar|null|Param, // Service id for custom faker instance. // Default: null
  *     },
  *     instantiator?: array{ // Configure the default instantiator used by your object factories.
  *         use_constructor?: bool|Param, // Use the constructor to instantiate objects. // Default: true
  *         allow_extra_attributes?: bool|Param, // Whether or not to skip attributes that do not correspond to properties. // Default: false
  *         always_force_properties?: bool|Param, // Whether or not to skip setters and force set object properties (public/private/protected) directly. // Default: false
- *         service?: scalar|Param|null, // Service id of your custom instantiator. // Default: null
+ *         service?: scalar|null|Param, // Service id of your custom instantiator. // Default: null
  *     },
- *     global_state?: list<scalar|Param|null>,
+ *     global_state?: list<scalar|null|Param>,
  *     persistence?: array{
  *         flush_once?: bool|Param, // Flush only once per call of `PersistentObjectFactory::create()` in userland. // Default: false
  *     },
  *     orm?: array{
  *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist entities when created. // Default: true
  *         reset?: array{
- *             connections?: list<scalar|Param|null>,
- *             entity_managers?: list<scalar|Param|null>,
+ *             connections?: list<scalar|null|Param>,
+ *             entity_managers?: list<scalar|null|Param>,
  *             mode?: \Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::SCHEMA|\Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::MIGRATE|Param, // Reset mode to use with ResetDatabase trait // Default: "schema"
  *             migrations?: array{
- *                 configurations?: list<scalar|Param|null>,
+ *                 configurations?: list<scalar|null|Param>,
  *             },
  *         },
  *     },
  *     mongo?: array{
  *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist documents when created. // Default: true
  *         reset?: array{
- *             document_managers?: list<scalar|Param|null>,
+ *             document_managers?: list<scalar|null|Param>,
  *         },
  *     },
  *     make_factory?: array{
- *         default_namespace?: scalar|Param|null, // Default namespace where factories will be created by maker. // Default: "Factory"
+ *         default_namespace?: scalar|null|Param, // Default namespace where factories will be created by maker. // Default: "Factory"
  *         add_hints?: bool|Param, // Add "beginner" hints in the created factory. // Default: true
  *     },
  *     make_story?: array{
- *         default_namespace?: scalar|Param|null, // Default namespace where stories will be created by maker. // Default: "Story"
+ *         default_namespace?: scalar|null|Param, // Default namespace where stories will be created by maker. // Default: "Story"
  *     },
  * }
  * @psalm-type SymfonycastsSassConfig = array{
- *     root_sass?: list<scalar|Param|null>,
- *     binary?: scalar|Param|null, // The Sass binary to use // Default: null
+ *     root_sass?: list<scalar|null|Param>,
+ *     binary?: scalar|null|Param, // The Sass binary to use // Default: null
  *     sass_options?: array{
  *         style?: "compressed"|"expanded"|Param, // The style of the generated CSS: compressed or expanded. // Default: "expanded"
  *         charset?: bool|Param, // Whether to include the charset declaration in the generated Sass.
@@ -1274,56 +1256,58 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         source_map?: bool|Param, // Whether to generate source maps. // Default: true
  *         embed_sources?: bool|Param, // Embed source file contents in source maps.
  *         embed_source_map?: bool|Param, // Embed source map contents in CSS. // Default: "%kernel.debug%"
- *         load_path?: list<scalar|Param|null>,
+ *         load_path?: list<scalar|null|Param>,
  *         quiet?: bool|Param, // Don't print warnings.
  *         quiet_deps?: bool|Param, // Don't print compiler warnings from dependencies.
  *         stop_on_error?: bool|Param, // Don't compile more files once an error is encountered.
  *         trace?: bool|Param, // Print full Dart stack traces for exceptions.
  *     },
- *     embed_sourcemap?: bool|Param|null, // Deprecated: Option "embed_sourcemap" at "symfonycasts_sass.embed_sourcemap" is deprecated. Use "sass_options.embed_source_map" instead". // Default: null
+ *     embed_sourcemap?: bool|null|Param, // Deprecated: Option "embed_sourcemap" at "symfonycasts_sass.embed_sourcemap" is deprecated. Use "sass_options.embed_source_map" instead". // Default: null
  * }
  * @psalm-type UxIconsConfig = array{
- *     icon_dir?: scalar|Param|null, // The local directory where icons are stored. // Default: "%kernel.project_dir%/assets/icons"
- *     default_icon_attributes?: array<string, scalar|Param|null>,
+ *     icon_dir?: scalar|null|Param, // The local directory where icons are stored. // Default: "%kernel.project_dir%/assets/icons"
+ *     default_icon_attributes?: array<string, scalar|null|Param>,
  *     icon_sets?: array<string, array{ // the icon set prefix (e.g. "acme") // Default: []
- *         path?: scalar|Param|null, // The local icon set directory path. (cannot be used with 'alias')
- *         alias?: scalar|Param|null, // The remote icon set identifier. (cannot be used with 'path')
- *         icon_attributes?: array<string, scalar|Param|null>,
+ *         path?: scalar|null|Param, // The local icon set directory path. (cannot be used with 'alias')
+ *         alias?: scalar|null|Param, // The remote icon set identifier. (cannot be used with 'path')
+ *         icon_attributes?: array<string, scalar|null|Param>,
  *         suffixes?: array<string, array{ // The suffix name (e.g. "solid", "20-solid") // Default: []
- *             icon_attributes?: array<string, scalar|Param|null>,
+ *             icon_attributes?: array<string, scalar|null|Param>,
  *         }>,
  *     }>,
  *     aliases?: array<string, string|Param>,
  *     iconify?: bool|array{ // Configuration for the remote icon service.
  *         enabled?: bool|Param, // Default: true
  *         on_demand?: bool|Param, // Whether to download icons "on demand". // Default: true
- *         endpoint?: scalar|Param|null, // The endpoint for the Iconify icons API. // Default: "https://api.iconify.design"
+ *         endpoint?: scalar|null|Param, // The endpoint for the Iconify icons API. // Default: "https://api.iconify.design"
  *     },
  *     ignore_not_found?: bool|Param, // Ignore error when an icon is not found. Set to 'true' to fail silently. // Default: false
  * }
  * @psalm-type UxMapConfig = array{
- *     renderer?: scalar|Param|null, // Default: null
+ *     renderer?: scalar|null|Param, // Default: null
  *     google_maps?: array{
- *         default_map_id?: scalar|Param|null, // Default: null
+ *         default_map_id?: scalar|null|Param, // Default: null
  *     },
  * }
+ * @psalm-type UxToolkitConfig = array<mixed>
  * @psalm-type TalesFromADevTwigExtraTailwindConfig = array{
  *     tailwind_merge?: array{
  *         additional_configuration?: mixed, // Default: []
  *     },
  * }
  * @psalm-type SymfonycastsTailwindConfig = array{
- *     input_css?: list<scalar|Param|null>,
- *     config_file?: scalar|Param|null, // Path to the tailwind.config.js file // Default: "%kernel.project_dir%/tailwind.config.js"
- *     binary?: scalar|Param|null, // The tailwind binary to use instead of downloading a new one // Default: null
- *     binary_version?: scalar|Param|null, // Tailwind CLI version to download - null means the latest version // Default: null
+ *     input_css?: list<scalar|null|Param>,
+ *     config_file?: scalar|null|Param, // Path to the tailwind.config.js file // Default: "%kernel.project_dir%/tailwind.config.js"
+ *     binary?: scalar|null|Param, // The tailwind binary to use instead of downloading a new one // Default: null
+ *     binary_version?: scalar|null|Param, // Tailwind CLI version to download - null means the latest version // Default: null
  *     binary_platform?: "auto"|"linux-arm64"|"linux-arm64-musl"|"linux-x64"|"linux-x64-musl"|"macos-arm64"|"macos-x64"|"windows-x64"|Param, // Tailwind CLI platform to download - "auto" will try to detect the platform automatically // Default: "auto"
- *     postcss_config_file?: scalar|Param|null, // Path to PostCSS config file which is passed to the Tailwind CLI // Default: null
- *     strict_mode?: bool|Param|null, // When enabled, an exception will be thrown if there are no built assets (default: false in `test` env, true otherwise) // Default: null
+ *     postcss_config_file?: scalar|null|Param, // Path to PostCSS config file which is passed to the Tailwind CLI // Default: null
+ *     strict_mode?: bool|null|Param, // When enabled, an exception will be thrown if there are no built assets (default: false in `test` env, true otherwise) // Default: null
  * }
  * @psalm-type UxNativeConfig = array{
- *     output_dir?: scalar|Param|null, // Directory where configuration JSON files are written. Defaults to %kernel.project_dir%/public. // Default: null
+ *     output_dir?: scalar|null|Param, // Directory where configuration JSON files are written. Defaults to %kernel.project_dir%/public. // Default: null
  * }
+ * @psalm-type UxCalendarLinkConfig = array<mixed>
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1346,9 +1330,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     symfonycasts_sass?: SymfonycastsSassConfig,
  *     ux_icons?: UxIconsConfig,
  *     ux_map?: UxMapConfig,
+ *     ux_toolkit?: UxToolkitConfig,
  *     tales_from_a_dev_twig_extra_tailwind?: TalesFromADevTwigExtraTailwindConfig,
  *     symfonycasts_tailwind?: SymfonycastsTailwindConfig,
  *     ux_native?: UxNativeConfig,
+ *     ux_calendar_link?: UxCalendarLinkConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1375,9 +1361,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         symfonycasts_sass?: SymfonycastsSassConfig,
  *         ux_icons?: UxIconsConfig,
  *         ux_map?: UxMapConfig,
+ *         ux_toolkit?: UxToolkitConfig,
  *         tales_from_a_dev_twig_extra_tailwind?: TalesFromADevTwigExtraTailwindConfig,
  *         symfonycasts_tailwind?: SymfonycastsTailwindConfig,
  *         ux_native?: UxNativeConfig,
+ *         ux_calendar_link?: UxCalendarLinkConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1401,9 +1389,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         symfonycasts_sass?: SymfonycastsSassConfig,
  *         ux_icons?: UxIconsConfig,
  *         ux_map?: UxMapConfig,
+ *         ux_toolkit?: UxToolkitConfig,
  *         tales_from_a_dev_twig_extra_tailwind?: TalesFromADevTwigExtraTailwindConfig,
  *         symfonycasts_tailwind?: SymfonycastsTailwindConfig,
  *         ux_native?: UxNativeConfig,
+ *         ux_calendar_link?: UxCalendarLinkConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1429,9 +1419,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         symfonycasts_sass?: SymfonycastsSassConfig,
  *         ux_icons?: UxIconsConfig,
  *         ux_map?: UxMapConfig,
+ *         ux_toolkit?: UxToolkitConfig,
  *         tales_from_a_dev_twig_extra_tailwind?: TalesFromADevTwigExtraTailwindConfig,
  *         symfonycasts_tailwind?: SymfonycastsTailwindConfig,
  *         ux_native?: UxNativeConfig,
+ *         ux_calendar_link?: UxCalendarLinkConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,
@@ -1450,10 +1442,7 @@ final class App
      */
     public static function config(array $config): array
     {
-        /** @var ConfigType $config */
-        $config = AppReference::config($config);
-
-        return $config;
+        return AppReference::config($config);
     }
 }
 

--- a/src/Service/CommonMark/ConverterFactory.php
+++ b/src/Service/CommonMark/ConverterFactory.php
@@ -24,6 +24,7 @@ use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\Mention\MentionExtension;
 use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -43,9 +44,9 @@ final class ConverterFactory
     ) {
     }
 
-    public function __invoke(): CommonMarkConverter
+    public function __invoke(bool $withTableOfContents = false): CommonMarkConverter
     {
-        $converter = new CommonMarkConverter([
+        $config = [
             'default_attributes' => [
                 Table::class => [
                     'class' => 'Wysiwyg_Table',
@@ -67,13 +68,25 @@ final class ConverterFactory
                 'internal_hosts' => ['/(^|\.)symfony\.com$/'],
             ],
             'heading_permalink' => [
-                'id_prefix' => 'content',
                 'apply_id_to_heading' => true,
-                'insert' => 'none',
+                // Headings only need their `id` for anchors when rendered as content.
+                // The table of contents needs the permalink nodes in the AST to be generated.
+                'insert' => $withTableOfContents ? 'before' : 'none',
             ],
-        ]);
+        ];
 
-        $converter->getEnvironment()
+        if ($withTableOfContents) {
+            $config['table_of_contents'] = [
+                'min_heading_level' => 2,
+                'max_heading_level' => 3,
+                'normalize' => 'flat',
+                'position' => 'top',
+            ];
+        }
+
+        $converter = new CommonMarkConverter($config);
+
+        $environment = $converter->getEnvironment()
             ->addExtension(new DefaultAttributesExtension())
             ->addExtension(new ExternalLinkExtension())
             ->addExtension(new MentionExtension())
@@ -85,6 +98,10 @@ final class ConverterFactory
             ->addExtension(new ToolkitPreviewExtension($this->uriSigner, $this->urlGenerator, $this->twig))
             ->addRenderer(FencedCode::class, new FencedCodeRenderer($this->componentRenderer))
         ;
+
+        if ($withTableOfContents) {
+            $environment->addExtension(new TableOfContentsExtension());
+        }
 
         return $converter;
     }

--- a/src/Service/CommonMark/ConverterFactory.php
+++ b/src/Service/CommonMark/ConverterFactory.php
@@ -24,7 +24,6 @@ use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\Mention\MentionExtension;
 use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableExtension;
-use League\CommonMark\Extension\TableOfContents\TableOfContentsExtension;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -44,9 +43,9 @@ final class ConverterFactory
     ) {
     }
 
-    public function __invoke(bool $withTableOfContents = false): CommonMarkConverter
+    public function __invoke(): CommonMarkConverter
     {
-        $config = [
+        $converter = new CommonMarkConverter([
             'default_attributes' => [
                 Table::class => [
                     'class' => 'Wysiwyg_Table',
@@ -68,25 +67,13 @@ final class ConverterFactory
                 'internal_hosts' => ['/(^|\.)symfony\.com$/'],
             ],
             'heading_permalink' => [
+                'id_prefix' => 'content',
                 'apply_id_to_heading' => true,
-                // Headings only need their `id` for anchors when rendered as content.
-                // The table of contents needs the permalink nodes in the AST to be generated.
-                'insert' => $withTableOfContents ? 'before' : 'none',
+                'insert' => 'none',
             ],
-        ];
+        ]);
 
-        if ($withTableOfContents) {
-            $config['table_of_contents'] = [
-                'min_heading_level' => 2,
-                'max_heading_level' => 3,
-                'normalize' => 'flat',
-                'position' => 'top',
-            ];
-        }
-
-        $converter = new CommonMarkConverter($config);
-
-        $environment = $converter->getEnvironment()
+        $converter->getEnvironment()
             ->addExtension(new DefaultAttributesExtension())
             ->addExtension(new ExternalLinkExtension())
             ->addExtension(new MentionExtension())
@@ -98,10 +85,6 @@ final class ConverterFactory
             ->addExtension(new ToolkitPreviewExtension($this->uriSigner, $this->urlGenerator, $this->twig))
             ->addRenderer(FencedCode::class, new FencedCodeRenderer($this->componentRenderer))
         ;
-
-        if ($withTableOfContents) {
-            $environment->addExtension(new TableOfContentsExtension());
-        }
 
         return $converter;
     }

--- a/src/Twig/Components/Toolkit/ComponentDoc.php
+++ b/src/Twig/Components/Toolkit/ComponentDoc.php
@@ -12,7 +12,14 @@
 namespace App\Twig\Components\Toolkit;
 
 use App\Enum\ToolkitKitId;
+use App\Service\CommonMark\ConverterFactory;
 use App\Service\Toolkit\ToolkitService;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\TableOfContents\Node\TableOfContents as TocNode;
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Node\NodeIterator;
+use League\CommonMark\Parser\MarkdownParser;
 use Symfony\UX\Toolkit\Recipe\Recipe;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -22,13 +29,60 @@ final class ComponentDoc
     public ToolkitKitId $kitId;
     public Recipe $component;
 
+    private ?string $markdownContent = null;
+
     public function __construct(
         private readonly ToolkitService $toolkitService,
+        private readonly ConverterFactory $converterFactory,
     ) {
     }
 
     public function getMarkdownContent(): string
     {
-        return $this->toolkitService->renderRecipeMarkdown($this->kitId, $this->component);
+        return $this->markdownContent ??= $this->toolkitService->renderRecipeMarkdown($this->kitId, $this->component);
+    }
+
+    /**
+     * @return list<array{level: int, title: string, id: string}>
+     */
+    public function getTocItems(): array
+    {
+        $converter = ($this->converterFactory)(withTableOfContents: true);
+        $document = new MarkdownParser($converter->getEnvironment())
+            ->parse($this->getMarkdownContent());
+
+        $headingLevels = [];
+        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
+            if ($node instanceof Heading) {
+                $id = $node->data->get('attributes/id', null);
+                if (null !== $id) {
+                    $headingLevels[$id] = $node->getLevel();
+                }
+            }
+        }
+
+        $tocNode = $document->firstChild();
+        if (!$tocNode instanceof TocNode) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($tocNode->iterator() as $node) {
+            if (!$node instanceof Link) {
+                continue;
+            }
+
+            $id = ltrim($node->getUrl(), '#');
+            $firstChild = $node->firstChild();
+            $title = $firstChild instanceof Text ? $firstChild->getLiteral() : '';
+
+            $items[] = [
+                'level' => $headingLevels[$id] ?? 2,
+                'title' => $title,
+                'id' => $id,
+            ];
+        }
+
+        return $items;
     }
 }

--- a/src/Twig/Components/Toolkit/ComponentDoc.php
+++ b/src/Twig/Components/Toolkit/ComponentDoc.php
@@ -15,11 +15,9 @@ use App\Enum\ToolkitKitId;
 use App\Service\CommonMark\ConverterFactory;
 use App\Service\Toolkit\ToolkitService;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
-use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
-use League\CommonMark\Extension\TableOfContents\Node\TableOfContents as TocNode;
-use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Node\NodeIterator;
 use League\CommonMark\Parser\MarkdownParser;
+use League\CommonMark\Renderer\HtmlRenderer;
 use Symfony\UX\Toolkit\Recipe\Recipe;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -47,38 +45,26 @@ final class ComponentDoc
      */
     public function getTocItems(): array
     {
-        $converter = ($this->converterFactory)(withTableOfContents: true);
-        $document = new MarkdownParser($converter->getEnvironment())
-            ->parse($this->getMarkdownContent());
-
-        $headingLevels = [];
-        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
-            if ($node instanceof Heading) {
-                $id = $node->data->get('attributes/id', null);
-                if (null !== $id) {
-                    $headingLevels[$id] = $node->getLevel();
-                }
-            }
-        }
-
-        $tocNode = $document->firstChild();
-        if (!$tocNode instanceof TocNode) {
-            return [];
-        }
+        $environment = ($this->converterFactory)()->getEnvironment();
+        $document = new MarkdownParser($environment)->parse($this->getMarkdownContent());
+        $renderer = new HtmlRenderer($environment);
 
         $items = [];
-        foreach ($tocNode->iterator() as $node) {
-            if (!$node instanceof Link) {
+        foreach ($document->iterator(NodeIterator::FLAG_BLOCKS_ONLY) as $node) {
+            if (!$node instanceof Heading) {
                 continue;
             }
-
-            $id = ltrim($node->getUrl(), '#');
-            $firstChild = $node->firstChild();
-            $title = $firstChild instanceof Text ? $firstChild->getLiteral() : '';
-
+            $level = $node->getLevel();
+            if ($level < 2 || $level > 3) {
+                continue;
+            }
+            $id = $node->data->get('attributes/id', null);
+            if (null === $id) {
+                continue;
+            }
             $items[] = [
-                'level' => $headingLevels[$id] ?? 2,
-                'title' => $title,
+                'level' => $level,
+                'title' => (string) $renderer->renderNodes($node->children()),
                 'id' => $id,
             ];
         }

--- a/templates/components/Toolkit/ComponentDoc.html.twig
+++ b/templates/components/Toolkit/ComponentDoc.html.twig
@@ -1,3 +1,21 @@
-<div class="Wysiwyg">
-    {{ this.markdownContent|markdown_to_html }}
+<div class="flex gap-8 items-start">
+    <div class="flex-1 min-w-0 Wysiwyg">
+        {{ this.markdownContent|markdown_to_html }}
+    </div>
+
+    {% if computed.tocItems %}
+        <nav class="hidden xl:block w-48 shrink-0 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-sm" aria-label="On this page">
+            <strong class="font-semibold mb-2 text-foreground block">On this page</strong>
+            <ul class="list-unstyled space-y-1">
+                {% for item in computed.tocItems %}
+                    <li{% if item.level == 3 %} class="pl-3"{% endif %}>
+                        <a href="#{{ item.id }}"
+                           class="block py-0.5 text-foreground/60 hover:text-foreground transition-colors duration-100 leading-snug break-words">
+                            {{ item.title }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </nav>
+    {% endif %}
 </div>

--- a/templates/components/Toolkit/ComponentDoc.html.twig
+++ b/templates/components/Toolkit/ComponentDoc.html.twig
@@ -4,14 +4,18 @@
     </div>
 
     {% if computed.tocItems %}
-        <nav class="hidden xl:block w-48 shrink-0 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-sm" aria-label="On this page">
-            <strong class="font-semibold mb-2 text-foreground block">On this page</strong>
+        <nav data-controller="toolkit-recipe-toc"
+             class="hidden xl:block w-48 shrink-0 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto text-sm" aria-label="On this page">
+            <strong class="font-semibold px-2 mb-2 text-foreground block">On this page</strong>
             <ul class="list-unstyled space-y-1">
                 {% for item in computed.tocItems %}
-                    <li{% if item.level == 3 %} class="pl-3"{% endif %}>
-                        <a href="#{{ item.id }}"
-                           class="block py-0.5 text-foreground/60 hover:text-foreground transition-colors duration-100 leading-snug break-words">
-                            {{ item.title }}
+                    {% set class = item.level == 3 ? 'ml-2' %}
+                    <li
+                        class="rounded transition-colors duration-100 ease-in-out hover:bg-surface [&.active]:bg-surface {{ class }}"
+                        data-toolkit-recipe-toc-target="link"
+                    >
+                        <a href="#{{ item.id }}" class="block px-2 py-0.5 text-[.9rem]">
+                            {{ item.title|raw }}
                         </a>
                     </li>
                 {% endfor %}

--- a/templates/toolkit/component.html.twig
+++ b/templates/toolkit/component.html.twig
@@ -25,7 +25,7 @@
     <div class="max-w-[1140px] mx-auto pt-6" style="display: grid; grid-template-columns: 180px 1fr; gap: 2rem">
         {{ include('toolkit/_kit_aside.html.twig') }}
 
-        <div>
+        <div class="min-w-0">
             <div class="flex items-center justify-between gap-4 flex-wrap">
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb">

--- a/templates/toolkit/docs/_base_component.md.twig
+++ b/templates/toolkit/docs/_base_component.md.twig
@@ -100,7 +100,7 @@ Happy coding!
 ## API Reference
 
 {% for component_name, component_api_reference in api_reference %}
-### Component `{{ component_name }}`
+### `{{ '<' }}twig:{{ component_name }}{{ '>' }}`
 
 {% if component_api_reference.props is not empty %}
 | Prop   | Type  | Description  |


### PR DESCRIPTION
Add a sticky table of contents on Toolkit component documentation pages, listing h2/h3 headings with anchor links.

| Q       | A
| ------- | ---
| Issues  | Fix #12
| License | MIT

| Before       | After
| ------- | ---
| <img width="1920" height="5380" alt="FireShot Capture 077 - Component Button - Shadcn UI Kit - Symfony UX -  ux symfony com" src="https://github.com/user-attachments/assets/f770406e-b833-484a-b081-a98030c3e8ef" /> | <img width="1920" height="5690" alt="FireShot Capture 078 - Component Button - Shadcn UI Kit - Symfony UX -  127 0 0 1" src="https://github.com/user-attachments/assets/687a64a1-c0c0-4205-8345-f9393565846d" />