### PR TITLE
[Toolkit] Add a Default column to the API Reference props table

### DIFF
--- a/src/Service/Toolkit/ToolkitService.php
+++ b/src/Service/Toolkit/ToolkitService.php
@@ -100,7 +100,7 @@ class ToolkitService
     }
 
     /**
-     * @return array<string, array{props: list<array{name: string, type: string, description: string}>, blocks: list<array{name: string, description: string}>}>
+     * @return array<string, array{props: list<array{name: string, type: string, default: string|null, description: string}>, blocks: list<array{name: string, description: string}>}>
      */
     public function extractRecipeApiReference(Recipe $recipe): array
     {
@@ -130,11 +130,18 @@ class ToolkitService
                     ->toString();
 
                 $apiReference[$componentName] = [
-                    'props' => array_map(static fn (array $prop) => [
-                        'name' => $prop['name'],
-                        'type' => $prop['type'],
-                        'description' => trim(preg_replace('/\s+/', ' ', $prop['description'])),
-                    ], $props),
+                    'props' => array_map(static function (array $prop) {
+                        ['description' => $description, 'default' => $default] = self::extractPropDefault(
+                            trim(preg_replace('/\s+/', ' ', $prop['description']))
+                        );
+
+                        return [
+                            'name' => $prop['name'],
+                            'type' => $prop['type'],
+                            'default' => $default,
+                            'description' => $description,
+                        ];
+                    }, $props),
                     'blocks' => array_map(static fn (array $block) => [
                         'name' => $block['name'],
                         'description' => trim(preg_replace('/\s+/', ' ', $block['description'])),
@@ -144,5 +151,20 @@ class ToolkitService
         }
 
         return $apiReference;
+    }
+
+    /**
+     * Splits the normalized "Defaults to `...`" suffix out of a prop description
+     * so the default value can be displayed in its own column. See symfony/ux#3345.
+     *
+     * @return array{description: string, default: string|null}
+     */
+    public static function extractPropDefault(string $description): array
+    {
+        if (preg_match('/^(?P<description>.*?)\s*Defaults to `(?P<default>.*)`$/', $description, $matches)) {
+            return ['description' => $matches['description'], 'default' => $matches['default']];
+        }
+
+        return ['description' => $description, 'default' => null];
     }
 }

--- a/templates/toolkit/docs/_base_component.md.twig
+++ b/templates/toolkit/docs/_base_component.md.twig
@@ -103,10 +103,10 @@ Happy coding!
 ### Component `{{ component_name }}`
 
 {% if component_api_reference.props is not empty %}
-| Prop   | Type  | Description  |
-|:-------|:------|:-------------|
+| Prop   | Type  | Default  | Description  |
+|:-------|:------|:---------|:-------------|
 {% for prop in component_api_reference.props %}
-| `{{ prop.name }}` | `{{ prop.type|replace({'|': '\\|'})|raw }}` | {{ prop.description }} |
+| `{{ prop.name }}` | `{{ prop.type|replace({'|': '\\|'})|raw }}` | {% if prop.default is not null %}`{{ prop.default|replace({'|': '\\|'})|raw }}`{% endif %} | {{ prop.description }} |
 {% endfor %}
 {% endif %}
 

--- a/tests/Unit/Service/Toolkit/ToolkitServiceTest.php
+++ b/tests/Unit/Service/Toolkit/ToolkitServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Unit\Service\Toolkit;
+
+use App\Service\Toolkit\ToolkitService;
+use PHPUnit\Framework\TestCase;
+
+class ToolkitServiceTest extends TestCase
+{
+    /**
+     * @dataProvider provideDescriptionsWithDefault
+     */
+    public function testExtractPropDefault(string $description, string $expectedDescription, ?string $expectedDefault)
+    {
+        $this->assertSame(
+            ['description' => $expectedDescription, 'default' => $expectedDefault],
+            ToolkitService::extractPropDefault($description),
+        );
+    }
+
+    public static function provideDescriptionsWithDefault(): iterable
+    {
+        yield 'a regular default value' => [
+            'The visual style variant. Defaults to `brand`',
+            'The visual style variant.',
+            'brand',
+        ];
+
+        yield 'a boolean default value' => [
+            'Whether the alert can be dismissible. Defaults to `false`',
+            'Whether the alert can be dismissible.',
+            'false',
+        ];
+
+        yield 'an empty default value' => [
+            'Define the open Tabs at initial rendering. Defaults to ``',
+            'Define the open Tabs at initial rendering.',
+            '',
+        ];
+
+        yield 'no default value' => [
+            'A description without any default value',
+            'A description without any default value',
+            null,
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Issues        | Fix #15
| License       | MIT

In the Toolkit `API Reference` section, the default value of a prop was buried inside the description (e.g. *"The visual style variant. Defaults to `brand`"*). This extracts it into its own `Default` column, as suggested by @Kocal in the issue:

| Prop | Type | Default | Description |
| ---- | ---- | ------- | ----------- |
| `variant` | `'brand'\|'gray'` | `brand` | The visual style variant. |

Since @Kocal already normalized the `@prop` descriptions to the `Defaults to \`...\`` format in symfony/ux#3345, this only needs to parse that suffix out at render time:
- `ToolkitService::extractPropDefault()` splits the normalized `Defaults to \`...\`` suffix from the description (returns `null` when absent, and an empty string for `Defaults to \`\``).
- the `_base_component.md.twig` table gets the extra `Default` column.

Added a unit test covering a regular value, a boolean, an empty default and a description without any default.

> [!NOTE]
> The project requires PHP >= 8.5 and I'm on 8.4 locally, so I could only run the new unit test (which needs neither the kernel nor PHP 8.5 features). It passes; CI will cover the rest.