### PR TITLE
[Toolkit][Shadcn] Add Sonner component docs and preview

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -11,6 +11,7 @@ import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
 import ToggleGroup from '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js';
 import Combobox from '@symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js';
+import Sonner from '@symfony/ux-toolkit/kits/shadcn/sonner/assets/controllers/sonner_controller.js';
 
 const app = startStimulusApp();
 app.register('accordion', Accordion);
@@ -24,3 +25,4 @@ app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);
 app.register('toggle-group', ToggleGroup);
 app.register('combobox', Combobox);
+app.register('sonner', Sonner);

--- a/importmap.php
+++ b/importmap.php
@@ -202,6 +202,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/sonner/assets/controllers/sonner_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/sonner/assets/controllers/sonner_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/sonner.md.twig
+++ b/templates/toolkit/docs/shadcn/sonner.md.twig
@@ -1,0 +1,29 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Types
+{{ toolkit_code_example(kit_id.value, component.name, 'Types') }}
+
+### With Description
+{{ toolkit_code_example(kit_id.value, component.name, 'With Description') }}
+
+### With Action
+{{ toolkit_code_example(kit_id.value, component.name, 'With Action') }}
+
+### Rich Colors
+{{ toolkit_code_example(kit_id.value, component.name, 'Rich Colors') }}
+
+### Position
+{{ toolkit_code_example(kit_id.value, component.name, 'Position') }}
+
+### Server Rendered
+{{ toolkit_code_example(kit_id.value, component.name, 'Server Rendered') }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to https://github.com/symfony/ux/pull/3477
| License        | MIT

- Register the sonner Stimulus controller (toolkit-shadcn.js + importmap)
- Add the Sonner documentation page with examples

https://github.com/user-attachments/assets/c68c684c-ebf7-40fa-b4ae-ed37d17d9afc

