### PR TITLE
[Toolkit][Shadcn] Add Combobox component docs and preview

### DIFF
--- a/assets/toolkit-shadcn.js
+++ b/assets/toolkit-shadcn.js
@@ -10,6 +10,7 @@ import Resizable from '@symfony/ux-toolkit/kits/shadcn/resizable/assets/controll
 import Tooltip from '@symfony/ux-toolkit/kits/shadcn/tooltip/assets/controllers/tooltip_controller.js';
 import Toggle from '@symfony/ux-toolkit/kits/shadcn/toggle/assets/controllers/toggle_controller.js';
 import ToggleGroup from '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js';
+import Combobox from '@symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js';
 
 const app = startStimulusApp();
 app.register('accordion', Accordion);
@@ -22,3 +23,4 @@ app.register('tabs', Tabs);
 app.register('tooltip', Tooltip);
 app.register('toggle', Toggle);
 app.register('toggle-group', ToggleGroup);
+app.register('combobox', Combobox);

--- a/importmap.php
+++ b/importmap.php
@@ -199,6 +199,9 @@ return [
     '@symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/shadcn/toggle-group/assets/controllers/toggle_group_controller.js',
     ],
+    '@symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js' => [
+        'path' => './vendor/symfony/ux-toolkit/kits/shadcn/combobox/assets/controllers/combobox_controller.js',
+    ],
     '@symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js' => [
         'path' => './vendor/symfony/ux-toolkit/kits/flowbite-4/alert/assets/controllers/alert_controller.js',
     ],

--- a/templates/toolkit/docs/shadcn/combobox.md.twig
+++ b/templates/toolkit/docs/shadcn/combobox.md.twig
@@ -1,0 +1,32 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '550px'}) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### With Default Value
+{{ toolkit_code_example(kit_id.value, component.name, 'With Default Value', {height: '550px'}) }}
+
+### With Form
+{{ toolkit_code_example(kit_id.value, component.name, 'With Form', {height: '550px'}) }}
+
+### Disabled
+{{ toolkit_code_example(kit_id.value, component.name, 'Disabled') }}
+
+### Clearable
+{{ toolkit_code_example(kit_id.value, component.name, 'Clearable', {height: '550px'}) }}
+
+### With Groups
+{{ toolkit_code_example(kit_id.value, component.name, 'With Groups', {height: '600px'}) }}
+
+### Empty State
+{{ toolkit_code_example(kit_id.value, component.name, 'Empty State', {height: '550px'}) }}
+
+### Long List
+{{ toolkit_code_example(kit_id.value, component.name, 'Long List', {height: '550px'}) }}
+{% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Companion to https://github.com/symfony/ux/pull/3482
| License        | MIT

- Register the combobox Stimulus controller (toolkit-shadcn.js + importmap)
- Add the Combobox documentation page with examples


https://github.com/user-attachments/assets/c070b05c-aca1-478c-9e20-19a30f076a6e


