### PR TITLE
[Toolkit] Use new `ComponentDocParser`, add a `Default` column to the `API Reference` props table

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8240,16 +8240,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "3d04840005c5c345dc04a6df591c997f43b4aa0d"
+                "reference": "9e6f3ad5b43c938c8e75200b42633bff789ab2dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/3d04840005c5c345dc04a6df591c997f43b4aa0d",
-                "reference": "3d04840005c5c345dc04a6df591c997f43b4aa0d",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/9e6f3ad5b43c938c8e75200b42633bff789ab2dd",
+                "reference": "9e6f3ad5b43c938c8e75200b42633bff789ab2dd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4",
+                "phpstan/phpdoc-parser": "^2.0",
                 "symfony/console": "^7.4|^8.0",
                 "symfony/filesystem": "^7.4|^8.0",
                 "symfony/framework-bundle": "^7.4|^8.0",
@@ -8342,7 +8343,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-19T07:14:15+00:00"
+            "time": "2026-07-05T19:00:40+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/src/Service/Toolkit/ToolkitService.php
+++ b/src/Service/Toolkit/ToolkitService.php
@@ -19,6 +19,8 @@ use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Renderer\HtmlRenderer;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Path;
+use Symfony\UX\Toolkit\Component\ComponentDoc;
+use Symfony\UX\Toolkit\Component\ComponentDocParser;
 use Symfony\UX\Toolkit\Installer\Pool;
 use Symfony\UX\Toolkit\Installer\PoolResolver;
 use Symfony\UX\Toolkit\Kit\Kit;
@@ -33,21 +35,13 @@ class ToolkitService
     /** @var array<value-of<ToolkitKitId>, Kit> */
     private array $kits = [];
 
-    /**
-     * @see https://regex101.com/r/3JXNX7/1
-     */
-    private const RE_API_PROPS = '/{#\s+@prop\s+(?P<name>\w+)\s+(?P<type>[^\s]+)\s+(?P<description>.+?)\s+#}/s';
-
-    /**
-     * @see https://regex101.com/r/jYjXpq/1
-     */
-    private const RE_API_BLOCKS = '/{#\s+@block\s+(?P<name>\w+)\s+(?P<description>.+?)\s+#}/s';
-
     public function __construct(
-        #[Autowire(service: 'ux_toolkit.registry.registry_factory')]
-        private RegistryFactory $registryFactory,
         private Environment $twig,
         private ConverterFactory $converterFactory,
+        #[Autowire(service: 'ux_toolkit.registry.registry_factory')]
+        private RegistryFactory $registryFactory,
+        #[Autowire(service: 'ux_toolkit.component.component_doc_parser')]
+        private ComponentDocParser $componentDocParser,
     ) {
     }
 
@@ -138,47 +132,35 @@ class ToolkitService
     }
 
     /**
-     * @return array<string, array{props: list<array{name: string, type: string, description: string}>, blocks: list<array{name: string, description: string}>}>
+     * @return array<string, ComponentDoc>
      */
     public function extractRecipeApiReference(Recipe $recipe): array
     {
         $apiReference = [];
 
         foreach ($recipe->getFiles() as $file) {
+            if (!str_ends_with($file->sourceRelativePathName, '.html.twig')) {
+                continue;
+            }
+
             $filePath = Path::join($recipe->absolutePath, $file->sourceRelativePathName);
             if (!file_exists($filePath)) {
                 continue;
             }
 
-            $fileContent = s(file_get_contents($filePath));
+            $componentDoc = $this->componentDocParser->parse(file_get_contents($filePath));
 
-            // Twig files...
-            if (str_ends_with($file->sourceRelativePathName, '.html.twig')) {
-                $props = $fileContent->match(self::RE_API_PROPS, \PREG_SET_ORDER);
-                $blocks = $fileContent->match(self::RE_API_BLOCKS, \PREG_SET_ORDER);
-
-                if ([] === $props && [] === $blocks) {
-                    continue;
-                }
-
-                $componentName = s($file->sourceRelativePathName)
-                    ->replace('templates/components/', '')
-                    ->replace('.html.twig', '')
-                    ->replace('/', ':')
-                    ->toString();
-
-                $apiReference[$componentName] = [
-                    'props' => array_map(static fn (array $prop) => [
-                        'name' => $prop['name'],
-                        'type' => $prop['type'],
-                        'description' => trim(preg_replace('/\s+/', ' ', $prop['description'])),
-                    ], $props),
-                    'blocks' => array_map(static fn (array $block) => [
-                        'name' => $block['name'],
-                        'description' => trim(preg_replace('/\s+/', ' ', $block['description'])),
-                    ], $blocks),
-                ];
+            if ([] === $componentDoc->props && [] === $componentDoc->blocks) {
+                continue;
             }
+
+            $componentName = s($file->sourceRelativePathName)
+                ->replace('templates/components/', '')
+                ->replace('.html.twig', '')
+                ->replace('/', ':')
+                ->toString();
+
+            $apiReference[$componentName] = $componentDoc;
         }
 
         return $apiReference;

--- a/templates/toolkit/docs/_base_component.md.twig
+++ b/templates/toolkit/docs/_base_component.md.twig
@@ -105,10 +105,10 @@ Happy coding!
 ### `{{ '<' }}twig:{{ component_name }}{{ '>' }}`
 
 {% if component_api_reference.props is not empty %}
-| Prop   | Type  | Description  |
-|:-------|:------|:-------------|
+| Prop   | Type  | Default  | Description  |
+|:-------|:------|:---------|:-------------|
 {% for prop in component_api_reference.props %}
-| `{{ prop.name }}` | `{{ prop.type|replace({'|': '\\|'})|raw }}` | {{ prop.description }} |
+| `{{ prop.name }}` | `{{ prop.type|replace({'|': '\\|'})|raw }}` | {{ (prop.default is not null ? '`' ~ prop.default|replace({'|': '\\|'}) ~ '`' : '-')|raw }} | {{ prop.description }} |
 {% endfor %}
 {{ ' ' }}
 {% endif %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #15 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT


Replace https://github.com/symfony/ux.symfony.com/pull/139, requires https://github.com/symfony/ux/pull/3694


<img width="637" height="432" alt="image" src="https://github.com/user-attachments/assets/3dcf6a1f-d56f-465e-98f0-994eab0ae026" />
