### PR TITLE
[Autocomplete] Update Tom Select to 2.6.2

### DIFF
--- a/importmap.php
+++ b/importmap.php
@@ -63,9 +63,6 @@ return [
     '@hotwired/stimulus' => [
         'version' => '3.2.2',
     ],
-    'tom-select' => [
-        'version' => '2.3.1',
-    ],
     'react' => [
         'version' => '18.3.1',
     ],
@@ -142,10 +139,6 @@ return [
     '@formatjs/fast-memoize' => [
         'version' => '2.2.0',
     ],
-    'tom-select/dist/css/tom-select.bootstrap5.css' => [
-        'version' => '2.3.1',
-        'type' => 'css',
-    ],
     'cropperjs/dist/cropper.min.css' => [
         'version' => '1.6.2',
         'type' => 'css',
@@ -216,14 +209,6 @@ return [
     'el-transition' => [
         'version' => '0.0.7',
     ],
-    'tom-select/dist/css/tom-select.default.css' => [
-        'version' => '2.4.3',
-        'type' => 'css',
-    ],
-    'tom-select/dist/css/tom-select.bootstrap4.css' => [
-        'version' => '2.4.3',
-        'type' => 'css',
-    ],
     'react-dom/client' => [
         'version' => '18.3.1',
     ],
@@ -239,5 +224,26 @@ return [
     ],
     '@hotwired/hotwire-native-bridge' => [
         'version' => '1.2.2',
+    ],
+    'tom-select' => [
+        'version' => '2.6.2',
+    ],
+    'tom-select/dist/css/tom-select.bootstrap5.css' => [
+        'version' => '2.6.2',
+        'type' => 'css',
+    ],
+    'tom-select/dist/css/tom-select.default.css' => [
+        'version' => '2.6.2',
+        'type' => 'css',
+    ],
+    'tom-select/dist/css/tom-select.bootstrap4.css' => [
+        'version' => '2.6.2',
+        'type' => 'css',
+    ],
+    '@orchidjs/sifter' => [
+        'version' => '1.1.0',
+    ],
+    '@orchidjs/unicode-variants' => [
+        'version' => '1.1.2',
     ],
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Issues        | Related to symfony/ux#3369
| License       | MIT

The importmap pinned Tom Select 2.3.1, with its CSS files pinned at two different versions (2.3.1 and 2.4.3). Tom Select 2.6.0 ships the fix for the dropdown scrolling back to the top when the virtual scroll plugin loads the next page (orchidjs/tom-select#1017, reported in symfony/ux#3369), so this bumps everything to 2.6.2.

Done with `bin/console importmap:update tom-select …`, which also pins `@orchidjs/sifter` and `@orchidjs/unicode-variants`: since 2.6, the ESM build no longer inlines them.

Tested locally on the `/autocomplete` page: Tom Select initializes, the Ajax search and the virtual scroll both work, no console error.
