### PR TITLE
Common toolkit section

### DIFF
--- a/assets/icons/toolkit/common.svg
+++ b/assets/icons/toolkit/common.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24"><rect x="2.5" y="2.5" width="9" height="9" rx="2" fill="#fbbf24"/><rect x="12.5" y="2.5" width="9" height="9" rx="2" fill="#f472b6"/><rect x="2.5" y="12.5" width="9" height="9" rx="2" fill="#60a5fa"/><rect x="12.5" y="12.5" width="9" height="9" rx="2" fill="#34d399"/></svg>

--- a/assets/styles/toolkit-common.css
+++ b/assets/styles/toolkit-common.css
@@ -1,0 +1,19 @@
+@import "tailwindcss";
+
+/* Scan the `common` kit's demo/example templates for the Tailwind classes used. */
+@source "../../vendor/symfony/ux-toolkit/kits/common";
+
+@custom-variant dark (&:is(.dark *));
+
+/*
+ * The `common` kit is design-system agnostic and ships no styles, so the shared
+ * component preview `<body>` has no background of its own. Give these previews a
+ * theme-aware canvas so the demo buttons read well in both light and dark mode.
+ */
+body {
+    background-color: white;
+}
+
+.dark body {
+    background-color: #0a0a0a;
+}

--- a/assets/styles/vendor/_highlight.css
+++ b/assets/styles/vendor/_highlight.css
@@ -74,4 +74,37 @@
         background-color: #EA4334;
         color: #fff;
     }
+
+    /* Collapsible `class="..."` values (see HighlightExtension::collapseClasses). */
+    .hl-collapse {
+        cursor: pointer;
+    }
+
+    .hl-collapse-cb {
+        display: none;
+    }
+
+    .hl-collapse-dots {
+        padding: 0 0.45em;
+        border-radius: 0.35em;
+        background: rgba(255, 255, 255, 0.12);
+        opacity: 0.85;
+    }
+
+    .hl-collapse:hover .hl-collapse-dots {
+        background: rgba(255, 255, 255, 0.22);
+        opacity: 1;
+    }
+
+    .hl-collapse-full {
+        display: none;
+    }
+
+    .hl-collapse-cb:checked ~ .hl-collapse-full {
+        display: inline;
+    }
+
+    .hl-collapse-cb:checked ~ .hl-collapse-dots {
+        display: none;
+    }
 }

--- a/assets/toolkit-common.js
+++ b/assets/toolkit-common.js
@@ -1,0 +1,15 @@
+import './styles/toolkit-common.css';
+import { startStimulusApp } from '@symfony/stimulus-bundle';
+import * as Turbo from '@hotwired/turbo';
+
+// The `common` kit is design-system agnostic and ships no styling or
+// controllers of its own. Its demo/example templates use a few Tailwind
+// utility classes (compiled via toolkit-common.css) purely to look good in
+// this preview; we boot Stimulus for the iframe as the other kits do.
+startStimulusApp();
+
+// The `common` kit previews (PostLink/LogoutLink) submit real forms to our
+// /link capture endpoint, which responds 200 instead of redirecting. Turbo
+// Drive would intercept that and leave the iframe unchanged, so disable Drive
+// for this preview entrypoint only (other kits keep Turbo enabled).
+Turbo.session.drive = false;

--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,7 @@
         "tailwind:build": [
             "@php bin/console tailwind:build --minify assets/styles/app.css",
             "@php bin/console tailwind:build --minify assets/styles/demos/live-memory.css",
+            "@php bin/console tailwind:build --minify assets/styles/toolkit-common.css",
             "@php bin/console tailwind:build --minify assets/styles/toolkit-shadcn.css",
             "@php bin/console tailwind:build --minify assets/styles/toolkit-flowbite-4.css"
         ]

--- a/composer.lock
+++ b/composer.lock
@@ -8240,12 +8240,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "9e6f3ad5b43c938c8e75200b42633bff789ab2dd"
+                "reference": "674369c0479e0285b581682fd5e3ce175bb70f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/9e6f3ad5b43c938c8e75200b42633bff789ab2dd",
-                "reference": "9e6f3ad5b43c938c8e75200b42633bff789ab2dd",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/674369c0479e0285b581682fd5e3ce175bb70f30",
+                "reference": "674369c0479e0285b581682fd5e3ce175bb70f30",
                 "shasum": ""
             },
             "require": {
@@ -8343,7 +8343,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-05T19:00:40+00:00"
+            "time": "2026-07-17T09:13:23+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/config/packages/symfonycasts_tailwind.yaml
+++ b/config/packages/symfonycasts_tailwind.yaml
@@ -7,6 +7,7 @@ symfonycasts_tailwind:
 
     input_css:
         - assets/styles/app.css
+        - assets/styles/toolkit-common.css
         - assets/styles/toolkit-shadcn.css
         - assets/styles/toolkit-flowbite-4.css
         - assets/styles/demos/live-memory.css

--- a/importmap.php
+++ b/importmap.php
@@ -28,6 +28,10 @@ return [
         'path' => './assets/demos/live-memory.js',
         'entrypoint' => true,
     ],
+    'toolkit-common' => [
+        'path' => './assets/toolkit-common.js',
+        'entrypoint' => true,
+    ],
     'toolkit-shadcn' => [
         'path' => './assets/toolkit-shadcn.js',
         'entrypoint' => true,

--- a/src/Controller/LinkCaptureController.php
+++ b/src/Controller/LinkCaptureController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Catch-all endpoint used by the Toolkit `common` kit previews.
+ *
+ * The `PostLink` / `LogoutLink` components submit real forms; pointing them at
+ * `/link/...` lets us render back the request details (method, spoofed method,
+ * CSRF token, body) so the previews are interactive instead of hitting a 404.
+ */
+class LinkCaptureController extends AbstractController
+{
+    #[Route('/link/{path}', name: 'app_link_capture', requirements: ['path' => '.+'])]
+    public function capture(Request $request, string $path): Response
+    {
+        // Only serve same-origin iframe navigations (i.e. the Toolkit previews).
+        // These Fetch Metadata headers are set by the browser and cannot be
+        // forged by page scripts, so a direct visit or cross-site embed 404s.
+        if ('iframe' !== $request->headers->get('Sec-Fetch-Dest')
+            || 'same-origin' !== $request->headers->get('Sec-Fetch-Site')
+        ) {
+            throw $this->createNotFoundException();
+        }
+
+        $response = $this->render('link/capture.html.twig', [
+            'path' => $path,
+            'method' => $request->getMethod(),
+            'spoofed_method' => $request->request->get('_method'),
+            'csrf_token' => $request->request->get('_csrf_token'),
+            'body' => $request->request->all(),
+            'query' => $request->query->all(),
+        ]);
+
+        // Only our own pages may frame this response (browser-enforced).
+        $response->headers->set('Content-Security-Policy', "frame-ancestors 'self'");
+
+        return $response;
+    }
+}

--- a/src/Enum/ToolkitKitId.php
+++ b/src/Enum/ToolkitKitId.php
@@ -20,12 +20,14 @@ namespace App\Enum;
  */
 enum ToolkitKitId: string
 {
+    case Common = 'common';
     case Shadcn = 'shadcn';
     case Flowbite4 = 'flowbite-4';
 
     public function color(): string
     {
         return match ($this) {
+            self::Common => '#7c3aed',
             self::Shadcn => 'hsl(0,0%,0%)',
             self::Flowbite4 => 'hsl(221,79%,48%)',
         };

--- a/src/Service/CommonMark/Extension/FencedCode/FencedCodeRenderer.php
+++ b/src/Service/CommonMark/Extension/FencedCode/FencedCodeRenderer.php
@@ -42,6 +42,7 @@ final class FencedCodeRenderer implements NodeRendererInterface
             'code' => $code,
             'language' => $language,
             'filename' => $options['filename'] ?? null,
+            'collapseClass' => $options['collapseClass'] ?? false,
         ]);
     }
 }

--- a/src/Twig/Components/Code/CodeBlockInline.php
+++ b/src/Twig/Components/Code/CodeBlockInline.php
@@ -19,4 +19,10 @@ final class CodeBlockInline
     public string $code;
     public string $language;
     public ?string $filename = null;
+
+    /**
+     * When true, `class="..."` attribute values are collapsed to a click-to-expand
+     * `…` in the rendered snippet (used to hide presentation-only classes).
+     */
+    public bool $collapseClass = false;
 }

--- a/src/Twig/Extension/HighlightExtension.php
+++ b/src/Twig/Extension/HighlightExtension.php
@@ -32,12 +32,35 @@ final class HighlightExtension extends AbstractExtension
         ];
     }
 
-    public function highlight(string $code, string $language, ?int $startAt = null): string
+    public function highlight(string $code, string $language, ?int $startAt = null, bool $collapseClasses = false): string
     {
-        if (null !== $startAt) {
-            return $this->highlighter->withGutter($startAt)->parse($code, $language);
-        }
+        $highlighted = null !== $startAt
+            ? $this->highlighter->withGutter($startAt)->parse($code, $language)
+            : $this->highlighter->parse($code, $language);
 
-        return $this->highlighter->parse($code, $language);
+        return $collapseClasses ? $this->collapseClasses($highlighted) : $highlighted;
+    }
+
+    /**
+     * Collapse `class="..."` attribute values in already-highlighted code into a
+     * zero-JS, click-to-expand toggle. Tuned to the markup the Tempest highlighter
+     * emits for an attribute: `<span class="hl-property">class</span>=&quot;…&quot;`.
+     *
+     * Uses a `<label>` wrapping a hidden checkbox so every element stays inline
+     * (a `<details>`/`<summary>` renders with a line break inside `<pre>`).
+     */
+    private function collapseClasses(string $highlightedCode): string
+    {
+        return preg_replace_callback(
+            '#(<span class="hl-property">class</span>=&quot;)(.+?)(&quot;)#',
+            static fn (array $m): string => $m[1]
+                .'<label class="hl-collapse" title="Toggle classes">'
+                .'<input type="checkbox" class="hl-collapse-cb">'
+                .'<span class="hl-collapse-dots">&hellip;</span>'
+                .'<span class="hl-collapse-full">'.$m[2].'</span>'
+                .'</label>'
+                .$m[3],
+            $highlightedCode,
+        );
     }
 }

--- a/src/Twig/Extension/SecurityStubExtension.php
+++ b/src/Twig/Extension/SecurityStubExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Stubs the Twig functions normally provided by SecurityBundle.
+ *
+ * This demo site has no firewall configured, but the Toolkit `common` kit
+ * components (e.g. LogoutLink, PostLink) call `logout_path()` and
+ * `csrf_token()`. These stubs return placeholder values so the component
+ * previews can render without SecurityBundle / symfony/security-csrf.
+ */
+final class SecurityStubExtension extends AbstractExtension
+{
+    public function getFunctions(): iterable
+    {
+        yield new TwigFunction('logout_path', static fn (?string $key = null): string => '/link/logout'.($key ? '/'.$key : ''));
+        // Overrides the twig-bridge `csrf_token`, which needs a CsrfTokenManager.
+        yield new TwigFunction('csrf_token', static fn (string $tokenId): string => 'stub.'.$tokenId);
+    }
+}

--- a/templates/components/Code/CodeBlockInline.html.twig
+++ b/templates/components/Code/CodeBlockInline.html.twig
@@ -41,7 +41,7 @@
         {% endif %}
         <div class="Terminal_content">
             <pre><code class="language-{{ language }}">
-                {{- code|highlight(language) -}}
+                {{- code|highlight(language, collapse_classes: collapseClass) -}}
             </code></pre>
         </div>
     </div>

--- a/templates/link/capture.html.twig
+++ b/templates/link/capture.html.twig
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Link captured</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+        const theme = localStorage.getItem('user-theme');
+        if (theme) {
+            document.documentElement.classList.add(theme);
+        }
+    </script>
+    <style>
+        :root { color-scheme: light dark; --bg: #fff; --fg: #1c1c1c; --muted: #6b7280; --border: #e5e7eb; --card: #f9fafb; --accent: #7c3aed; }
+        html.dark { --bg: #0f172a; --fg: #e2e8f0; --muted: #94a3b8; --border: #1e293b; --card: #1e293b; --accent: #a78bfa; }
+        * { box-sizing: border-box; }
+        body { margin: 0; padding: .75rem; font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; background: var(--bg); color: var(--fg); }
+        h1 { font-size: 1.1rem; margin: 0 0 .6rem; display: flex; align-items: center; gap: .5rem; }
+        h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 1rem 0 .35rem; }
+        table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+        th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+        tr:last-child th, tr:last-child td { border-bottom: 0; }
+        th { width: 12rem; font-weight: 600; color: var(--muted); white-space: nowrap; }
+        code { font-family: ui-monospace, monospace; }
+        .method { display: inline-block; padding: .1rem .5rem; border-radius: 6px; background: var(--accent); color: #fff; font-weight: 700; font-family: ui-monospace, monospace; }
+        .empty { color: var(--muted); font-style: italic; }
+        .back { display: inline-flex; align-items: center; gap: .35rem; margin-bottom: .75rem; color: var(--accent); text-decoration: none; font-weight: 600; }
+        .back:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <a class="back" href="#" onclick="history.back(); return false;">&larr; Back</a>
+    <h1>🔗 Link captured</h1>
+    <table>
+        <tr><th>Request path</th><td><code>/{{ path }}</code></td></tr>
+        <tr><th>HTTP method</th><td><span class="method">{{ method }}</span></td></tr>
+        {% if spoofed_method %}
+            <tr><th>Spoofed method <code>_method</code></th><td><span class="method">{{ spoofed_method|upper }}</span> <span class="empty">(needs <code>http_method_override</code> to take effect)</span></td></tr>
+        {% endif %}
+        {% if csrf_token %}
+            <tr><th>CSRF token <code>_csrf_token</code></th><td><code>{{ csrf_token }}</code></td></tr>
+        {% endif %}
+    </table>
+
+    {% if body is not empty %}
+        <h2>Body parameters</h2>
+        <table>
+            {% for key, value in body %}
+                <tr><th><code>{{ key }}</code></th><td><code>{{ value is iterable ? value|json_encode : value }}</code></td></tr>
+            {% endfor %}
+        </table>
+    {% endif %}
+
+    {% if query is not empty %}
+        <h2>Query parameters</h2>
+        <table>
+            {% for key, value in query %}
+                <tr><th><code>{{ key }}</code></th><td><code>{{ value is iterable ? value|json_encode : value }}</code></td></tr>
+            {% endfor %}
+        </table>
+    {% endif %}
+</body>
+</html>

--- a/templates/toolkit/docs/common/logout-link.md.twig
+++ b/templates/toolkit/docs/common/logout-link.md.twig
@@ -1,0 +1,42 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+
+> [!WARNING]
+> `LogoutLink` logs the user out through a **POST** request protected by a CSRF token (token id `logout`). For it to work, your firewall's logout must **require `POST`** and have **CSRF protection enabled** — otherwise logging out will be rejected.
+
+Restrict the logout route to `POST` so it can't be triggered by a plain link or prefetch:
+
+```php
+#[Route('/logout', name: 'app_logout', methods: ['POST'])]
+public function logout(): never
+{
+    throw new \LogicException('This method is intercepted by the logout key on your firewall.');
+}
+```
+
+Point the firewall's logout at that route (`app_logout`) and enable CSRF protection (this validates the `logout` token the component sends):
+
+```yaml
+# config/packages/security.yaml
+security:
+    firewalls:
+        main:
+            logout:
+                path: app_logout
+                enable_csrf: true
+```
+{% endblock %}
+
+{% block examples %}
+### Specific Firewall
+
+Set the `firewall` prop to log out from a specific firewall instead of the current one.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Specific Firewall', {height: '300px'}) }}
+{% endblock %}

--- a/templates/toolkit/docs/common/logout-link.md.twig
+++ b/templates/toolkit/docs/common/logout-link.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px'}) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '300px', collapseClass: true}) }}
 {% endblock %}
 
 {% block usage %}
@@ -38,5 +38,5 @@ security:
 
 Set the `firewall` prop to log out from a specific firewall instead of the current one.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Specific Firewall', {height: '300px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Specific Firewall', {height: '300px', collapseClass: true}) }}
 {% endblock %}

--- a/templates/toolkit/docs/common/post-link.md.twig
+++ b/templates/toolkit/docs/common/post-link.md.twig
@@ -1,0 +1,32 @@
+{% extends 'toolkit/docs/_base_component.md.twig' %}
+
+{% block demo %}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '190px'}) }}
+{% endblock %}
+
+{% block usage %}
+{{ toolkit_code_usage(kit_id.value, component.name) }}
+{% endblock %}
+
+{% block examples %}
+### Custom Method
+
+Set the `method` prop to submit the form with a spoofed HTTP method. A hidden `_method` field is added so Symfony can route the request to the matching controller.
+
+> [!WARNING]
+> Method spoofing only works when HTTP method override is enabled in your Symfony app. Set `framework.http_method_override: true` in `config/packages/framework.yaml`.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'Custom Method', {height: '300px'}) }}
+
+### With Confirmation
+
+Pass a `confirm` message to prompt the user with a native confirmation dialog before the form is submitted.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'With Confirmation', {height: '190px'}) }}
+
+### With CSRF Protection
+
+Set `csrfTokenId` to add a hidden CSRF token field, protecting the form against cross-site request forgery.
+
+{{ toolkit_code_example(kit_id.value, component.name, 'With CSRF Protection', {height: '300px'}) }}
+{% endblock %}

--- a/templates/toolkit/docs/common/post-link.md.twig
+++ b/templates/toolkit/docs/common/post-link.md.twig
@@ -1,7 +1,7 @@
 {% extends 'toolkit/docs/_base_component.md.twig' %}
 
 {% block demo %}
-{{ toolkit_code_demo(kit_id.value, component.name, {height: '190px'}) }}
+{{ toolkit_code_demo(kit_id.value, component.name, {height: '190px', collapseClass: true}) }}
 {% endblock %}
 
 {% block usage %}
@@ -16,17 +16,17 @@ Set the `method` prop to submit the form with a spoofed HTTP method. A hidden `_
 > [!WARNING]
 > Method spoofing only works when HTTP method override is enabled in your Symfony app. Set `framework.http_method_override: true` in `config/packages/framework.yaml`.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'Custom Method', {height: '300px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'Custom Method', {height: '300px', collapseClass: true}) }}
 
 ### With Confirmation
 
 Pass a `confirm` message to prompt the user with a native confirmation dialog before the form is submitted.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'With Confirmation', {height: '190px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'With Confirmation', {height: '190px', collapseClass: true}) }}
 
 ### With CSRF Protection
 
 Set `csrfTokenId` to add a hidden CSRF token field, protecting the form against cross-site request forgery.
 
-{{ toolkit_code_example(kit_id.value, component.name, 'With CSRF Protection', {height: '300px'}) }}
+{{ toolkit_code_example(kit_id.value, component.name, 'With CSRF Protection', {height: '300px', collapseClass: true}) }}
 {% endblock %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | https://github.com/symfony/ux/pull/3707
| License        | MIT

Adds the common toolkit from https://github.com/symfony/ux/pull/3707.

Also included here is "collapsible classes" for code blocks. The new `common` kit is CSS-framework agnostic, but the examples on ux.symfony.com use Tailwind to make them look nice. I didn't want those utility classes stealing focus from the code that actually matters, so I added an opt-in option to collapse them by default: `class="x y z"` renders as `class="…"`, and clicking the `…` expands it to reveal the full value. Here's what it looks like:

<img width="709" height="180" alt="Screenshot 2026-07-14 at 8 15 27 PM" src="https://github.com/user-attachments/assets/058b9990-8fe6-40cc-b122-82e9583fd385" />
