### PR TITLE
Register the closeable Stimulus controller in the common kit preview

### DIFF
--- a/assets/toolkit-common.js
+++ b/assets/toolkit-common.js
@@ -1,12 +1,15 @@
 import './styles/toolkit-common.css';
 import { startStimulusApp } from '@symfony/stimulus-bundle';
 import * as Turbo from '@hotwired/turbo';
+import Closeable from '@symfony/ux-toolkit/kits/common/closeable/assets/controllers/closeable_controller.js';
 
-// The `common` kit is design-system agnostic and ships no styling or
-// controllers of its own. Its demo/example templates use a few Tailwind
-// utility classes (compiled via toolkit-common.css) purely to look good in
-// this preview; we boot Stimulus for the iframe as the other kits do.
-startStimulusApp();
+// The `common` kit is design-system agnostic and ships no styling of its own.
+// Its demo/example templates use a few Tailwind utility classes (compiled via
+// toolkit-common.css) purely to look good in this preview. We boot Stimulus for
+// the iframe as the other kits do and register the kit's controllers by hand,
+// since `startStimulusApp()` only auto-discovers the app's own controllers.
+const app = startStimulusApp();
+app.register('closeable', Closeable);
 
 // The `common` kit previews (PostLink/LogoutLink) submit real forms to our
 // /link capture endpoint, which responds 200 instead of redirecting. Turbo

--- a/composer.lock
+++ b/composer.lock
@@ -8240,12 +8240,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "74457b83b403ad10e8fdfef3b86ad1f3265ce2b7"
+                "reference": "1bf162526c09108557424dd91948fa7793b26959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/74457b83b403ad10e8fdfef3b86ad1f3265ce2b7",
-                "reference": "74457b83b403ad10e8fdfef3b86ad1f3265ce2b7",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/1bf162526c09108557424dd91948fa7793b26959",
+                "reference": "1bf162526c09108557424dd91948fa7793b26959",
                 "shasum": ""
             },
             "require": {
@@ -8344,7 +8344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-23T06:07:01+00:00"
+            "time": "2026-07-23T23:40:14+00:00"
         },
         {
             "name": "symfony/ux-translator",


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | -
| License        | MIT

The `common` kit's `closeable` component ships a Stimulus controller, but the toolkit preview entrypoint only called `startStimulusApp()`, which auto-discovers the app's own controllers — not a kit's. So the `closeable` examples rendered but the behavior never ran.

This imports the controller from the kit and registers it explicitly on the preview's Stimulus app, mirroring how `toolkit-shadcn.js` already registers its kit controllers.

Depends on symfony/ux#3725 (adds the `closeable` recipe) — the imported `@symfony/ux-toolkit/kits/common/closeable/...` path only resolves once that recipe is released, so this should merge after it.
