### PR TITLE
Watch the toolkit-common entrypoint in the dev server

### DIFF
--- a/.symfony.local.yaml
+++ b/.symfony.local.yaml
@@ -4,6 +4,8 @@ workers:
         cmd: ['symfony', 'console', 'tailwind:build', '--watch', 'assets/styles/app.css', '-vvv']
     tailwind_toolkit_shadcn:
         cmd: ['symfony', 'console', 'tailwind:build', '--watch', 'assets/styles/toolkit-shadcn.css', '-vvv']
+    tailwind_toolkit_common:
+        cmd: ['symfony', 'console', 'tailwind:build', '--watch', 'assets/styles/toolkit-common.css', '-vvv']
     tailwind_live_memory:
         cmd: ['symfony', 'console', 'tailwind:build', '--watch', 'assets/styles/demos/live-memory.css', '-vvv']
 


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | -
| License        | MIT

`.symfony.local.yaml` runs a `tailwind:build --watch` worker per CSS entrypoint, but `toolkit-common` was missing one — so changes to the `common` kit's preview markup never recompiled its Tailwind CSS in local dev. This adds the matching `tailwind_toolkit_common` worker alongside the existing `app`, `shadcn`, and `live-memory` ones.
