### PR TITLE
Lazy-load component previews and add a reload button

### DIFF
--- a/assets/controllers/lazy-iframe-controller.js
+++ b/assets/controllers/lazy-iframe-controller.js
@@ -1,0 +1,45 @@
+import { Controller } from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['frame', 'loader'];
+    static values = { src: String };
+
+    // Load the preview only once it scrolls into view, so time-based demos
+    // (auto-close, delayed countdown) start their timers when the user is
+    // actually looking at them rather than while still below the fold.
+    connect() {
+        this.observer = new IntersectionObserver((entries) => this.#onIntersect(entries));
+        this.observer.observe(this.element);
+    }
+
+    disconnect() {
+        this.observer?.disconnect();
+    }
+
+    // Re-run the demo on demand (the frames load once, so this replays
+    // time-based examples that have already finished).
+    reload() {
+        this.#start();
+    }
+
+    loaded() {
+        this.loaderTarget.style.display = 'none';
+        this.frameTarget.removeAttribute('data-loading');
+    }
+
+    #onIntersect(entries) {
+        if (!entries.some((entry) => entry.isIntersecting)) {
+            return;
+        }
+
+        this.#start();
+        this.observer.disconnect();
+    }
+
+    #start() {
+        this.loaderTarget.style.display = '';
+        this.frameTarget.setAttribute('data-loading', '');
+        this.frameTarget.src = this.srcValue;
+    }
+}

--- a/templates/bundles/UXToolkitBundle/markdown/code_preview.html.twig
+++ b/templates/bundles/UXToolkitBundle/markdown/code_preview.html.twig
@@ -1,7 +1,10 @@
 {# Override of @UXToolkit/markdown/code_preview.html.twig: reuse ux.symfony.com's styled preview
    iframe (spinner + rounded frame). The Toolkit passes `previewUrl`, `height` and `code`. #}
 {% if previewUrl is defined and previewUrl %}
-    <div class="Toolkit_Preview relative">
+    <div class="Toolkit_Preview relative group"
+         data-controller="lazy-iframe"
+         data-lazy-iframe-src-value="{{ previewUrl }}"
+    >
         {{ include('toolkit/docs/_preview.html.twig') }}
     </div>
 {% else %}

--- a/templates/toolkit/docs/_preview.html.twig
+++ b/templates/toolkit/docs/_preview.html.twig
@@ -1,14 +1,22 @@
-<div class="absolute flex items-center justify-center gap-1 w-full" style="height: {{ height }};">
+<div data-lazy-iframe-target="loader" class="absolute flex items-center justify-center gap-1 w-full" style="height: {{ height }};">
     <svg width="18" height="18" viewBox="0 0 24 24" class="animate-spin">
         <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>
     </svg>
     <span>Loading...</span>
 </div>
+<button
+    type="button"
+    data-action="lazy-iframe#reload"
+    class="absolute top-2 right-2 z-10 inline-flex items-center justify-center rounded-md p-1.5 text-base leading-none text-gray-400 bg-white ring-1 ring-gray-200 shadow-sm hover:text-gray-700 dark:text-gray-500 dark:bg-gray-800/70 dark:ring-white/10 dark:hover:text-gray-200 backdrop-blur transition-colors"
+    aria-label="Reload preview"
+    title="Reload preview"
+>
+    <twig:ux:icon name="refresh" />
+</button>
 <iframe
     class="w-full transition-opacity duration-250 rounded-xl data-loading:opacity-0"
-    src="{{ previewUrl }}"
-    loading="lazy"
+    data-lazy-iframe-target="frame"
+    data-action="load->lazy-iframe#loaded"
     data-loading
     style="height: {{ height }};"
-    onload="this.previousElementSibling.style.display = 'none'; this.removeAttribute('data-loading')"
 ></iframe>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | -
| License        | MIT

Component doc pages embed one preview iframe per example. The iframes already carried the native `loading="lazy"` attribute, but that only defers loading and uses a generous heuristic that fetches frames well before they enter the viewport — and it does nothing to gate when a demo starts running. So time-based demos (a component that auto-dismisses after a few seconds) had often already finished by the time you scrolled to them, and looked broken.

A small `lazy-iframe` Stimulus controller replaces the attribute: it sets each iframe's `src` only once it actually scrolls into view (via `IntersectionObserver`, with no early margin), so those demos start when the user sees them. A reload button lets you replay a demo on demand.
