### PR TITLE
Improve the Toolkit landing page and docs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8240,12 +8240,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/ux-toolkit.git",
-                "reference": "1bf162526c09108557424dd91948fa7793b26959"
+                "reference": "f2a20516a3d22aa41c8a6c6d6b4a73c6e4e02861"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/1bf162526c09108557424dd91948fa7793b26959",
-                "reference": "1bf162526c09108557424dd91948fa7793b26959",
+                "url": "https://api.github.com/repos/symfony/ux-toolkit/zipball/f2a20516a3d22aa41c8a6c6d6b4a73c6e4e02861",
+                "reference": "f2a20516a3d22aa41c8a6c6d6b4a73c6e4e02861",
                 "shasum": ""
             },
             "require": {
@@ -8344,7 +8344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-23T23:40:14+00:00"
+            "time": "2026-07-24T18:25:57+00:00"
         },
         {
             "name": "symfony/ux-translator",

--- a/src/Service/Toolkit/ToolkitService.php
+++ b/src/Service/Toolkit/ToolkitService.php
@@ -60,7 +60,25 @@ class ToolkitService
      */
     public function getRecipeTocItems(string $kitId, Recipe $recipe): array
     {
-        return $this->renderRecipe($kitId, $recipe)->tableOfContents;
+        return array_map(
+            $this->shortenStimulusController(...),
+            $this->renderRecipe($kitId, $recipe)->tableOfContents,
+        );
+    }
+
+    /**
+     * The API-reference heading for a Stimulus controller reads `data-controller="foo"`, too wide for
+     * the narrow TOC sidebar. Show just the controller name there; the on-page heading is untouched.
+     *
+     * @param array{level: int, title: string, id: string} $item
+     *
+     * @return array{level: int, title: string, id: string}
+     */
+    private function shortenStimulusController(array $item): array
+    {
+        $item['title'] = preg_replace('/data-controller=(?:&quot;|")(.*?)(?:&quot;|")/', '$1', $item['title']);
+
+        return $item;
     }
 
     /**

--- a/templates/_footer.html.twig
+++ b/templates/_footer.html.twig
@@ -5,7 +5,7 @@
                 <p class="flex items-center justify-center xl:justify-end gap-2 mb-0">
                     <a href="https://github.com/symfony/ux" rel="external noopener noreferrer"
                        aria-label="Symfony UX on GitHub"
-                       class="lg:order-1 text-2xl"
+                       class="lg:order-1 text-2xl inline-flex items-center"
                     >
                         <twig:ux:icon name="github"/>
                     </a>
@@ -13,7 +13,7 @@
                     <a href="{{ url('app_changelog') }}" class="lg:order-0 text-[11px] uppercase">Changelog</a>
                     <a href="{{ url('app_support') }}" class="lg:order-0 text-[11px] uppercase">Support</a>
                     <a href="https://symfony.com" rel="external noopener noreferrer"
-                       class="text-2xl"
+                       class="text-2xl inline-flex items-center"
                        aria-label="Symfony website"
                     >
                         <twig:ux:icon name="symfony"/>

--- a/templates/bundles/UXToolkitBundle/markdown/code_preview.html.twig
+++ b/templates/bundles/UXToolkitBundle/markdown/code_preview.html.twig
@@ -1,12 +1,7 @@
 {# Override of @UXToolkit/markdown/code_preview.html.twig: reuse ux.symfony.com's styled preview
    iframe (spinner + rounded frame). The Toolkit passes `previewUrl`, `height` and `code`. #}
 {% if previewUrl is defined and previewUrl %}
-    <div class="Toolkit_Preview relative group"
-         data-controller="lazy-iframe"
-         data-lazy-iframe-src-value="{{ previewUrl }}"
-    >
-        {{ include('toolkit/docs/_preview.html.twig') }}
-    </div>
+    {{ include('toolkit/docs/_preview.html.twig') }}
 {% else %}
     <pre><code>{{ code }}</code></pre>
 {% endif %}

--- a/templates/components/Package/PackageHeader.html.twig
+++ b/templates/components/Package/PackageHeader.html.twig
@@ -32,6 +32,8 @@
                     Read the docs
                 </a>
             {% endif %}
+
+            {% block header_actions %}{% endblock %}
         </div>
     </div>
 </div>

--- a/templates/toolkit/docs/_preview.html.twig
+++ b/templates/toolkit/docs/_preview.html.twig
@@ -1,22 +1,27 @@
-<div data-lazy-iframe-target="loader" class="absolute flex items-center justify-center gap-1 w-full" style="height: {{ height }};">
-    <svg width="18" height="18" viewBox="0 0 24 24" class="animate-spin">
-        <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>
-    </svg>
-    <span>Loading...</span>
-</div>
-<button
-    type="button"
-    data-action="lazy-iframe#reload"
-    class="absolute top-2 right-2 z-10 inline-flex items-center justify-center rounded-md p-1.5 text-base leading-none text-gray-400 bg-white ring-1 ring-gray-200 shadow-sm hover:text-gray-700 dark:text-gray-500 dark:bg-gray-800/70 dark:ring-white/10 dark:hover:text-gray-200 backdrop-blur transition-colors"
-    aria-label="Reload preview"
-    title="Reload preview"
+<div class="Toolkit_Preview relative group"
+     data-controller="lazy-iframe"
+     data-lazy-iframe-src-value="{{ previewUrl }}"
 >
-    <twig:ux:icon name="refresh" />
-</button>
-<iframe
-    class="w-full transition-opacity duration-250 rounded-xl data-loading:opacity-0"
-    data-lazy-iframe-target="frame"
-    data-action="load->lazy-iframe#loaded"
-    data-loading
-    style="height: {{ height }};"
-></iframe>
+    <div data-lazy-iframe-target="loader" class="absolute flex items-center justify-center gap-1 w-full" style="height: {{ height }};">
+        <svg width="18" height="18" viewBox="0 0 24 24" class="animate-spin">
+            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>
+        </svg>
+        <span>Loading...</span>
+    </div>
+    <button
+        type="button"
+        data-action="lazy-iframe#reload"
+        class="absolute top-2 right-2 z-10 inline-flex items-center justify-center rounded-md p-1.5 text-base leading-none text-gray-400 bg-white ring-1 ring-gray-200 shadow-sm hover:text-gray-700 dark:text-gray-500 dark:bg-gray-800/70 dark:ring-white/10 dark:hover:text-gray-200 backdrop-blur transition-colors"
+        aria-label="Reload preview"
+        title="Reload preview"
+    >
+        <twig:ux:icon name="refresh" />
+    </button>
+    <iframe
+        class="w-full transition-opacity duration-250 rounded-xl data-loading:opacity-0"
+        data-lazy-iframe-target="frame"
+        data-action="load->lazy-iframe#loaded"
+        data-loading
+        style="height: {{ height }};"
+    ></iframe>
+</div>

--- a/templates/ux_packages/toolkit.html.twig
+++ b/templates/ux_packages/toolkit.html.twig
@@ -16,11 +16,21 @@
         {% block sub_content %}
             With Toolkit comes “Kits”, a set of ready-to-use and fully-customizable UI Twig components and more, to help you to build your Design System.
         {% endblock %}
+
+        {% block header_actions %}
+            <a
+                href="#kits"
+                class="bg-body flex border rounded gap-2 py-2 px-4 relative items-center transition-colors"
+            >
+                <twig:ux:icon name="mdi:view-grid-outline" class="Icon size-6" />
+                See the Kits
+            </a>
+        {% endblock %}
     {% endcomponent %}
 {% endblock %}
 
 {% block code_block_left %}
-<twig:Terminal>
+<twig:Terminal bottomPadding="20" class="h-full">
 # Install the components you need...
 php bin/console ux:install card
 php bin/console ux:install button
@@ -44,17 +54,18 @@ tree templates/components
         filename="templates/toolkit/_code_block_right.html.twig"
         :showFilename="false"
         height="auto"
+        class="h-full"
     />
 {% endblock %}
 
-{% block demo_title %}UX Toolkit{% endblock %}
-
-{% block demo_content %}
-    {% apply markdown_to_html %}
-    [toolkit-preview {"kit":"shadcn","height":"400px"}]
-    {{ source ('toolkit/_code_block_right.html.twig') }}
-    [/toolkit-preview]
-    {% endapply %}
+{% block package_demo %}
+    <div id="demo" class="mb-12">
+{% apply markdown_to_html %}
+[toolkit-preview {"kit":"shadcn","height":"300px"}]
+{{ source('toolkit/_code_block_right.html.twig') }}
+[/toolkit-preview]
+{% endapply %}
+    </div>
 {% endblock %}
 
 {% block package_install %}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | -
| License        | MIT

A handful of adjustments to the Toolkit section of the site:

- Fix the broken preview iframe on `/toolkit`: the lazy-load change moved the iframe `src` onto a `lazy-iframe` controller wrapper that the `[toolkit-preview]` renderer never had, so its iframe never loaded. The wrapper now lives in the shared `_preview.html.twig`.
- Add a "See the Kits" button beside the composer command in the header, via a new overridable `header_actions` block on `PackageHeader`, linking to the `#kits` section.
- Tighten the demo on `/toolkit`: shrink the terminal, match the two code panels' heights, drop the branded container chrome around the live preview, and reduce the preview height.
- Shorten Stimulus controller entries in the API-reference TOC so `data-controller="foo"` no longer wraps in the narrow sidebar — the TOC shows just the controller name; the on-page heading is unchanged.
- Vertically center the GitHub/Symfony icons in the footer.
- Bump `symfony/ux-toolkit` to the latest version.
