### PR TITLE
Add dark mode variants to the Toolkit alert component

### DIFF
--- a/templates/components/Toolkit/Alert.html.twig
+++ b/templates/components/Toolkit/Alert.html.twig
@@ -3,11 +3,11 @@
     base: 'flex gap-2 rounded-md p-2.5 my-1 [&_p]:my-1',
     variants: {
         variant: {
-            note: 'border-sky-500 bg-sky-50 text-sky-900',
-            tip: 'border-green-500 bg-green-50 text-green-900',
-            important: 'border-purple-500 bg-purple-50 text-purple-900',
-            warning: 'border-amber-500 bg-amber-50 text-amber-900',
-            caution: 'border-red-500 bg-red-50 text-red-900',
+            note: 'border-sky-500 bg-sky-50 text-sky-900 dark:bg-sky-950 dark:text-sky-300',
+            tip: 'border-green-500 bg-green-50 text-green-900 dark:bg-green-950 dark:text-green-300',
+            important: 'border-purple-500 bg-purple-50 text-purple-900 dark:bg-purple-950 dark:text-purple-300',
+            warning: 'border-amber-500 bg-amber-50 text-amber-900 dark:bg-amber-950 dark:text-amber-300',
+            caution: 'border-red-500 bg-red-50 text-red-900 dark:bg-red-950 dark:text-red-300',
         },
     },
 ) -%}


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | none
| License        | MIT

The `Toolkit/Alert` component (used by markdown admonitions) had light-only colors, so alerts rendered with light backgrounds in dark mode. This adds `dark:` variants to each variant.