### PR TITLE
Add a toolbar and auto-sizing to the Toolkit component preview

### DIFF
--- a/assets/controllers/preview-viewport-controller.js
+++ b/assets/controllers/preview-viewport-controller.js
@@ -1,0 +1,168 @@
+import { Controller } from '@hotwired/stimulus';
+
+const MIN_WIDTH = 280;
+const ZOOM_STEP = 0.1;
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 2;
+
+// Turns the preview iframe into a small sandbox: device presets, zoom, grid
+// overlay and a drag handle. Width holds the *emulated* viewport width in px
+// (0 = fluid, fills the available space); the visual box is that width scaled
+// by zoom, so an oversized device just scrolls horizontally.
+export default class extends Controller {
+    static targets = ['viewport', 'stage', 'frame', 'handle', 'zoomLabel', 'grid', 'gridBtn', 'preset'];
+    static values = {
+        width: { type: Number, default: 0 },
+        zoom: { type: Number, default: 1 },
+        grid: Boolean,
+        baseHeight: String,
+    };
+
+    connect() {
+        this.observer = new ResizeObserver(() => {
+            if (this.widthValue === 0) this.#render();
+        });
+        this.observer.observe(this.viewportTarget);
+        this.#render();
+    }
+
+    disconnect() {
+        this.observer?.disconnect();
+        this.contentObserver?.disconnect();
+        this.dragAbort?.abort();
+        cancelAnimationFrame(this._heightFrame);
+    }
+
+    setWidth({ params: { width } }) {
+        this.widthValue = Number(width);
+    }
+
+    zoomIn() {
+        this.zoomValue = Math.min(ZOOM_MAX, this.zoomValue + ZOOM_STEP);
+    }
+
+    zoomOut() {
+        this.zoomValue = Math.max(ZOOM_MIN, this.zoomValue - ZOOM_STEP);
+    }
+
+    toggleGrid() {
+        this.gridValue = !this.gridValue;
+    }
+
+    startResize(event) {
+        event.preventDefault();
+
+        // Anchor to the fixed centre of the viewport: width grows/shrinks
+        // symmetrically so the stage stays centred while dragging, and the
+        // handle (its right edge) tracks the pointer without feedback.
+        this._centerX = this.#viewportCenterX();
+        this.viewportTarget.classList.add('is-resizing');
+
+        this.handleTarget.setPointerCapture(event.pointerId);
+        this.dragAbort = new AbortController();
+        const { signal } = this.dragAbort;
+        this.handleTarget.addEventListener('pointermove', (e) => this.#resizeMove(e), { signal });
+        this.handleTarget.addEventListener('pointerup', (e) => this.#resizeEnd(e), { signal });
+    }
+
+    widthValueChanged() { this.#render(); }
+    zoomValueChanged() { this.#render(); }
+    gridValueChanged() { this.#render(); }
+
+    // Once the (same-origin) preview document is available, keep watching its
+    // content size so interactive demos that change height on their own (an
+    // accordion opening, a toggle expanding) stay fully visible, then measure.
+    frameLoaded() {
+        this.contentObserver?.disconnect();
+        try {
+            const doc = this.frameTarget.contentDocument;
+            const body = doc?.body;
+            if (body) {
+                // Padding is constant, so cache it here rather than reading it on
+                // every measure (the drag path runs #contentHeight each frame).
+                const style = doc.defaultView.getComputedStyle(body);
+                this.bodyPadding = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+
+                this.contentObserver = new ResizeObserver(() => this.#applyHeight());
+                for (const child of body.children) this.contentObserver.observe(child);
+            }
+        } catch {
+            // cross-origin: content height stays fixed to the base height
+        }
+        this.#render();
+    }
+
+    #resizeMove(event) {
+        const half = event.clientX - this._centerX;
+        this.widthValue = Math.max(MIN_WIDTH, Math.round((half * 2) / this.zoomValue));
+    }
+
+    #resizeEnd(event) {
+        this.handleTarget.releasePointerCapture(event.pointerId);
+        this.dragAbort.abort();
+        this.viewportTarget.classList.remove('is-resizing');
+    }
+
+    #viewportCenterX() {
+        const rect = this.viewportTarget.getBoundingClientRect();
+        return rect.left + this.viewportTarget.clientWidth / 2;
+    }
+
+    #render() {
+        const zoom = this.zoomValue;
+        const emWidth = this.widthValue > 0 ? this.widthValue : this.#availableWidth();
+
+        this.frameTarget.style.width = `${emWidth}px`;
+        this.frameTarget.style.transform = `scale(${zoom})`;
+        this.frameTarget.style.transformOrigin = 'top left';
+        this.stageTarget.style.width = `${emWidth * zoom}px`;
+
+        this.zoomLabelTarget.textContent = `${Math.round(zoom * 100)}%`;
+
+        this.gridTarget.hidden = !this.gridValue;
+        this.gridBtnTarget.setAttribute('aria-pressed', String(this.gridValue));
+
+        this.presetTargets.forEach((btn) => {
+            const active = Number(btn.dataset.previewViewportWidthParam) === this.widthValue;
+            btn.setAttribute('aria-pressed', String(active));
+        });
+
+        // Height depends on the iframe content reflowing to the new width, which
+        // isn't reliably synchronous — measure and apply it on the next frame.
+        cancelAnimationFrame(this._heightFrame);
+        this._heightFrame = requestAnimationFrame(() => this.#applyHeight());
+    }
+
+    #applyHeight() {
+        const height = this.#contentHeight();
+        this.frameTarget.style.height = `${height}px`;
+        this.stageTarget.style.height = `${height * this.zoomValue}px`;
+    }
+
+    #availableWidth() {
+        return Math.max(MIN_WIDTH, this.viewportTarget.clientWidth);
+    }
+
+    // Grow the frame to the preview's natural height when the content reflows
+    // taller than the configured base height (e.g. narrowed to mobile), so it
+    // never gets clipped. Measures the content element rather than body
+    // scrollHeight, which the body's flex-centering under-reports. Falls back to
+    // the base height before load or if the document is unreachable (cross-origin).
+    #contentHeight() {
+        const baseHeight = parseFloat(this.baseHeightValue) || 0;
+        try {
+            const body = this.frameTarget.contentDocument?.body;
+            if (!body || !body.children.length) return baseHeight;
+
+            let content = 0;
+            for (const child of body.children) content = Math.max(content, child.offsetHeight);
+
+            // Keep the body's own padding (cached at load) visible around the
+            // content — the body is border-box, so its padding eats into the
+            // configured height. Never shrink below the configured base height.
+            return Math.max(baseHeight, Math.ceil(content + (this.bodyPadding || 0)));
+        } catch {
+            return baseHeight;
+        }
+    }
+}

--- a/assets/icons/lucide/grid-2x2.svg
+++ b/assets/icons/lucide/grid-2x2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M12 3v18m-9-9h18"/><rect width="18" height="18" x="3" y="3" rx="2"/></g></svg>

--- a/assets/icons/lucide/monitor.svg
+++ b/assets/icons/lucide/monitor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="20" height="14" x="2" y="3" rx="2"/><path d="M8 21h8m-4-4v4"/></g></svg>

--- a/assets/icons/lucide/move-horizontal.svg
+++ b/assets/icons/lucide/move-horizontal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m18 8l4 4l-4 4M2 12h20M6 8l-4 4l4 4"/></svg>

--- a/assets/icons/lucide/smartphone.svg
+++ b/assets/icons/lucide/smartphone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/></g></svg>

--- a/assets/icons/lucide/tablet.svg
+++ b/assets/icons/lucide/tablet.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="16" height="20" x="4" y="2" rx="2" ry="2"/><path d="M12 18h.01"/></g></svg>

--- a/assets/icons/lucide/zoom-in.svg
+++ b/assets/icons/lucide/zoom-in.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21l-4.35-4.35M11 8v6m-3-3h6"/></g></svg>

--- a/assets/icons/lucide/zoom-out.svg
+++ b/assets/icons/lucide/zoom-out.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21l-4.35-4.35M8 11h6"/></g></svg>

--- a/assets/icons/mdi/view-grid-outline.svg
+++ b/assets/icons/mdi/view-grid-outline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3 11h8V3H3m2 2h4v4H5m8 12h8v-8h-8m2 2h4v4h-4M3 21h8v-8H3m2 2h4v4H5m8-16v8h8V3m-2 6h-4V5h4Z"/></svg>

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -136,6 +136,7 @@
 @import "./components/_Icon.css";
 @import "./components/_ProductGrid.css";
 @import "./components/_Terminal.css";
+@import "./components/_ToolkitPreview.css";
 @import "./components/_Wysiwyg.css";
 
 /* ─── Utilities ─── */

--- a/assets/styles/components/_ToolkitPreview.css
+++ b/assets/styles/components/_ToolkitPreview.css
@@ -1,0 +1,36 @@
+@layer components {
+    /* Alignment grid overlay (adapted from Storybook): a coarse 100px grid over
+       a fine 20px one, blended with `difference` so the lines stay legible on
+       both light and dark previews. */
+    .Toolkit_Preview_grid {
+        background-image:
+            linear-gradient(rgba(130, 130, 130, 0.5) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(130, 130, 130, 0.5) 1px, transparent 1px),
+            linear-gradient(rgba(130, 130, 130, 0.25) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(130, 130, 130, 0.25) 1px, transparent 1px);
+        background-size: 100px 100px, 100px 100px, 20px 20px, 20px 20px;
+        background-position: 16px 16px, 16px 16px, 16px 16px, 16px 16px;
+        background-blend-mode: difference;
+        /* Overlay sits over the iframe, so invert against the content behind it
+           (not just the layers) to stay legible on light and dark previews. */
+        mix-blend-mode: difference;
+    }
+
+    /* Resize handle grip: a pseudo-element pill that fades in while hovering
+       the preview or actively dragging. */
+    .Toolkit_Preview_handle::before {
+        content: "";
+        width: 4px;
+        height: --spacing(8);
+        max-height: 60%;
+        border-radius: 9999px;
+        background: --alpha(var(--color-body-text) / 25%);
+        opacity: 0;
+        transition: opacity 150ms ease-in-out;
+    }
+
+    .Toolkit_Preview:hover .Toolkit_Preview_handle::before,
+    .is-resizing .Toolkit_Preview_handle::before {
+        opacity: 1;
+    }
+}

--- a/templates/toolkit/component.html.twig
+++ b/templates/toolkit/component.html.twig
@@ -22,7 +22,7 @@
 {% block content %}
     <div class="pt-20"></div>
 
-    <div class="max-w-[1140px] mx-auto lg:pt-6 grid grid-cols-1 lg:grid-cols-[180px_1fr] gap-8 px-4 lg:px-0">
+    <div class="max-w-[1140px] xl:max-w-[1280px] 2xl:max-w-[1440px] mx-auto lg:pt-6 grid grid-cols-1 lg:grid-cols-[180px_1fr] gap-8 px-4 lg:px-0">
         <div class="hidden lg:block">
             {{ include('toolkit/_kit_aside.html.twig') }}
         </div>

--- a/templates/toolkit/docs/_preview.html.twig
+++ b/templates/toolkit/docs/_preview.html.twig
@@ -1,27 +1,70 @@
-<div class="Toolkit_Preview relative group"
-     data-controller="lazy-iframe"
+{% set pressed_class = '[&[aria-pressed=true]]:bg-surface' %}
+{% set presets = [
+    {width: 0, icon: 'lucide:move-horizontal', label: 'Responsive'},
+    {width: 375, icon: 'lucide:smartphone', label: 'Mobile (375px)'},
+    {width: 768, icon: 'lucide:tablet', label: 'Tablet (768px)'},
+    {width: 1280, icon: 'lucide:monitor', label: 'Desktop (1280px)'},
+] %}
+
+<div class="Toolkit_Preview border border-border rounded-xl overflow-hidden bg-subtle"
+     data-controller="lazy-iframe preview-viewport"
      data-lazy-iframe-src-value="{{ previewUrl }}"
+     data-preview-viewport-base-height-value="{{ height }}"
 >
-    <div data-lazy-iframe-target="loader" class="absolute flex items-center justify-center gap-1 w-full" style="height: {{ height }};">
-        <svg width="18" height="18" viewBox="0 0 24 24" class="animate-spin">
-            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>
-        </svg>
-        <span>Loading...</span>
+    <div class="flex flex-wrap items-center gap-2 px-2 py-1.5 border-b border-border bg-surface/50">
+        <div role="group" aria-label="Viewport size" class="flex items-center gap-0.5">
+            {% for preset in presets %}
+                <twig:Button variant="ghost" size="icon-sm" aria-label="{{ preset.label }}" title="{{ preset.label }}" aria-pressed="false"
+                    class="{{ pressed_class }}"
+                    data-preview-viewport-target="preset" data-preview-viewport-width-param="{{ preset.width }}"
+                    data-action="preview-viewport#setWidth">
+                    <twig:ux:icon name="{{ preset.icon }}" class="size-4" />
+                </twig:Button>
+            {% endfor %}
+        </div>
+
+        <div class="ml-auto flex items-center gap-1">
+            <twig:Button variant="ghost" size="icon-sm" aria-label="Zoom out" title="Zoom out" data-action="preview-viewport#zoomOut">
+                <twig:ux:icon name="lucide:zoom-out" class="size-4" />
+            </twig:Button>
+            <span class="text-xs tabular-nums w-10 text-center text-body-text/70" data-preview-viewport-target="zoomLabel">100%</span>
+            <twig:Button variant="ghost" size="icon-sm" aria-label="Zoom in" title="Zoom in" data-action="preview-viewport#zoomIn">
+                <twig:ux:icon name="lucide:zoom-in" class="size-4" />
+            </twig:Button>
+
+            <twig:Button variant="ghost" size="icon-sm" aria-label="Toggle grid" title="Toggle grid" aria-pressed="false"
+                class="{{ pressed_class }}"
+                data-preview-viewport-target="gridBtn" data-action="preview-viewport#toggleGrid">
+                <twig:ux:icon name="lucide:grid-2x2" class="size-4" />
+            </twig:Button>
+
+            <twig:Button variant="ghost" size="icon-sm" aria-label="Reload preview" title="Reload preview" data-action="lazy-iframe#reload">
+                <twig:ux:icon name="refresh" class="Icon size-4" />
+            </twig:Button>
+        </div>
     </div>
-    <button
-        type="button"
-        data-action="lazy-iframe#reload"
-        class="absolute top-2 right-2 z-10 inline-flex items-center justify-center rounded-md p-1.5 text-base leading-none text-gray-400 bg-white ring-1 ring-gray-200 shadow-sm hover:text-gray-700 dark:text-gray-500 dark:bg-gray-800/70 dark:ring-white/10 dark:hover:text-gray-200 backdrop-blur transition-colors"
-        aria-label="Reload preview"
-        title="Reload preview"
-    >
-        <twig:ux:icon name="refresh" />
-    </button>
-    <iframe
-        class="w-full transition-opacity duration-250 rounded-xl data-loading:opacity-0"
-        data-lazy-iframe-target="frame"
-        data-action="load->lazy-iframe#loaded"
-        data-loading
-        style="height: {{ height }};"
-    ></iframe>
+
+    <div class="relative overflow-auto min-w-0 [&.is-resizing]:cursor-col-resize [&.is-resizing]:select-none" data-preview-viewport-target="viewport">
+        <div data-lazy-iframe-target="loader" class="absolute inset-0 flex items-center justify-center gap-1">
+            <svg width="18" height="18" viewBox="0 0 24 24" class="animate-spin">
+                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 1 1-6.219-8.56"/>
+            </svg>
+            <span>Loading...</span>
+        </div>
+
+        <div class="relative mx-auto" data-preview-viewport-target="stage">
+            <iframe
+                class="block border-0 bg-white transition-opacity duration-250 data-loading:opacity-0"
+                data-lazy-iframe-target="frame"
+                data-preview-viewport-target="frame"
+                data-action="load->lazy-iframe#loaded load->preview-viewport#frameLoaded"
+                data-loading
+            ></iframe>
+            <div class="Toolkit_Preview_grid absolute inset-0 pointer-events-none" data-preview-viewport-target="grid" hidden></div>
+            <div class="Toolkit_Preview_handle absolute inset-y-0 right-0 w-3 flex items-center justify-center cursor-col-resize touch-none"
+                 role="separator" aria-orientation="vertical" aria-label="Resize preview"
+                 data-preview-viewport-target="handle"
+                 data-action="pointerdown->preview-viewport#startResize"></div>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | n/a
| License        | MIT

The iframe preview on component documentation pages used to show a loading spinner and a small floating reload button. This PR turns it into a proper sandbox by adding a toolbar above the frame.

The toolbar has four viewport presets (responsive, mobile 375px, tablet 768px, desktop 1280px), zoom out / zoom in controls with a percentage readout, an alignment-grid toggle, and the reload button (moved from its floating position into the toolbar). A drag handle on the right edge lets you resize the frame freely; it stays centered while dragging. When an emulated device width is wider than the available space, the preview scrolls horizontally instead of shrinking the content.

The frame also auto-fits its height: because the preview document is same-origin, the controller can measure the content and grow the frame to keep everything visible (including padding) whenever the content reflows (narrowing to mobile, an accordion opening, and so on). It never drops below the minimum height the Toolkit configured.

A few other things worth noting:

- The alignment grid is adapted from Storybook: a coarse 100px grid over a fine 20px one, blended so the lines stay legible on both light and dark previews.
- The component documentation page container is widened at the `xl` and `2xl` breakpoints so previews actually have room to reach tablet and desktop widths.

https://github.com/user-attachments/assets/b718803c-edc7-4c1c-9e06-45f95b6a8cad


