### PR TITLE
Minor website fixes and adjustments

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -60,7 +60,7 @@
     --color-border-subtle: #343a40;
     --color-border-translucent: rgba(255, 255, 255, .175);
     --color-code: #ff79c6;
-    --color-code-bg: --alpha(var(--color-pink-500) / 10%);
+    --color-code-bg: transparent;
 
     --color-link: #6ea8fe;
 }
@@ -131,6 +131,7 @@
 
 /* ─── Components ─── */
 @import "./components/_container.css";
+@import "./components/_Card.css";
 @import "./components/_typography.css";
 @import "./components/_DemoContainer.css";
 @import "./components/_Icon.css";

--- a/assets/styles/components/_Card.css
+++ b/assets/styles/components/_Card.css
@@ -1,0 +1,26 @@
+@layer components {
+    .Tag {
+        display: inline-flex;
+        align-items: center;
+        max-inline-size: 100%;
+        padding-block: .25rem;
+        padding-inline: .5rem;
+        border: 1px solid var(--color-border-subtle);
+        border-radius: var(--radius-sm);
+        background-color: var(--color-subtle);
+        color: var(--color-body-text);
+        font-family: var(--font-sans);
+        font-size: .8rem;
+        font-stretch: semi-condensed;
+        font-weight: 400;
+        line-height: 1.25;
+        list-style: none;
+        overflow-wrap: anywhere;
+    }
+
+    .stretched-link::after {
+        position: absolute;
+        inset: 0;
+        content: "";
+    }
+}

--- a/templates/_header.html.twig
+++ b/templates/_header.html.twig
@@ -31,7 +31,6 @@
                         <twig:ux:icon name="x-twitter"/>
                     </twig:AppNav:IconLink>
                     <twig:AppNav:IconLink href="https://bsky.app/profile/ux.symfony.com" title="Symfony UX on BlueSky">
-                        <twig:AppNav:Badge />
                         <twig:ux:icon name="bluesky"/>
                     </twig:AppNav:IconLink>
                     <twig:AppNav:IconLink href="https://github.com/symfony/ux" title="Symfony UX on GitHub">

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -10,7 +10,7 @@
             <span class="eyebrows" style="font-size: 1rem;">Error</span>
             <h1 style="font-size: calc(6rem + 10vw); line-height: .75;letter-spacing: -.5rem;">{{ status_code }}</h1>
             <p class="Wysiwyg w-1/2 text-balance max-xl:w-3/5 max-[734px]:w-4/5">{{ status_text }}</p>
-            <twig:Button href="{{ url('app_homepage') }}" variant="outline" class="after:absolute after:inset-0">Back to the homepage</twig:Button>
+            <twig:LinkButton outline label="Back to the homepage" url="{{ url('app_homepage') }}" class="after:absolute after:inset-0" />
         </div>
     </main>
 {% endblock %}

--- a/templates/components/Box.html.twig
+++ b/templates/components/Box.html.twig
@@ -1,3 +1,7 @@
+{% props radius = 'md' %}
+
+{% set radius_class = radius == 'xl' ? 'rounded-xl before:rounded-xl after:rounded-xl' : 'rounded-md before:rounded-md after:rounded-md' %}
+
 {% set attr_style = [
     '--color: ' ~ color,
     '--gradient: ' ~ gradient ?: 'none',
@@ -5,7 +9,7 @@
 ]|join(' ;') %}
 
 <div
-    class="group relative flex gap-3 p-3 sm:gap-6 sm:p-6 self-stretch border border-surface rounded-md bg-body transition-all duration-750 ease-in-out hover:-translate-y-1 hover:duration-200 before:content-[''] before:absolute before:top-1 before:inset-x-0 before:-bottom-1 before:rounded-md before:opacity-0 before:blur-md before:-z-10 before:transition-opacity before:duration-600 before:[background-image:var(--gradient)] before:bg-black/50 hover:before:opacity-25 hover:before:duration-250 after:content-[''] after:absolute after:inset-0 after:rounded-md after:bg-body after:-z-10 after:opacity-95 after:transition-opacity after:duration-600 hover:after:opacity-[0.99] hover:after:duration-250"
+    class="group relative flex gap-3 p-3 sm:gap-6 sm:p-6 self-stretch border border-surface {{ radius_class }} bg-body transition-all duration-750 ease-in-out hover:-translate-y-1 hover:duration-200 before:content-[''] before:absolute before:top-1 before:inset-x-0 before:-bottom-1 before:opacity-0 before:blur-md before:-z-10 before:transition-opacity before:duration-600 before:[background-image:var(--gradient)] before:bg-black/50 hover:before:opacity-25 hover:before:duration-250 after:content-[''] after:absolute after:inset-0 after:bg-body after:-z-10 after:opacity-95 after:transition-opacity after:duration-600 hover:after:opacity-[0.99] hover:after:duration-250"
     style="{{ attr_style }}"
 >
     {% block badge %}{% endblock %}

--- a/templates/components/Card.html.twig
+++ b/templates/components/Card.html.twig
@@ -1,7 +1,7 @@
 {% props name, image, url, description, tags, lazyload = true %}
 
-<article class="group rounded-xl relative flex flex-col border transition-all duration-250 ease-in-out hover:—translate-y-1 hover:shadow-lg hover:scale-102 ">
-    <div class="rounded-t-xl bg-black place-content-center grid overflow-hidden aspect-video">
+<article class="Card group rounded-xl relative flex flex-col overflow-hidden border transition-all duration-250 ease-in-out hover:-translate-y-1 hover:shadow-lg hover:scale-[1.02]">
+    <div class="bg-black place-content-center grid aspect-video">
         <img class="object-cover block max-w-full transition-opacity opacity-95 group-hover:opacity-100"
              src="{{ image }}"
              width="640"
@@ -10,7 +10,7 @@
         >
     </div>
 
-    <div class="py-4 px-6 flex-1 rounded-b-xl gap-2 flex flex-col">
+    <div class="py-4 px-6 flex-1 gap-2 flex flex-col">
         <h4 class="text-lg font-bold m-0">
             <a href="{{ url }}" class="stretched-link">
                 {{ name }}

--- a/templates/components/DocsLink.html.twig
+++ b/templates/components/DocsLink.html.twig
@@ -1,11 +1,11 @@
 <a
     {{ attributes.defaults({
         href: url,
-        rel: isExternal ? 'external noopened noreferrer' : false,
+        rel: isExternal ? 'external noopener noreferrer' : false,
     }).without('class') }}
-    class="rounded-2xl flex flex-col p-6 relative place-self-stretch bg-body opacity-90 transition duration-250 ease-in-out hover:-translate-y-1 hover:opacity-100 hover:shadow-md"
+    class="rounded-xl flex flex-col p-6 relative place-self-stretch bg-body opacity-90 transition duration-250 ease-in-out hover:-translate-y-1 hover:opacity-100 hover:shadow-md"
 >
-    <div class="flex flex-">
+    <div class="flex flex-1">
         <span class="h4 font-bold font-stretch-condensed tracking-tight flex-1">
             {{ title }}
         </span>

--- a/templates/components/Icon/IconSetCard.html.twig
+++ b/templates/components/Icon/IconSetCard.html.twig
@@ -1,11 +1,11 @@
 {% set sample_icons = this.getSampleIcons() %}
 {% set samples = sample_icons|length %}
 <article
-    class="rounded-md relative flex flex-col transition duration-250 ease-in-out hover:-translate-y-2 shadow-sm hover:shadow-xl text-(--iconset-color)"
+    class="rounded-xl relative flex flex-col overflow-hidden transition duration-250 ease-in-out hover:-translate-y-2 shadow-sm hover:shadow-xl text-(--iconset-color)"
     data-iconset="{{ this.iconSet.identifier }}"
     style="--index: {{ index }}; --hue: calc(var(--index) * 77); --iconset-color: lch(70% 110 var(--hue, 240)); --iconset-color-bg: lch(80% 30 var(--hue, 240));"
 >
-    <div class="rounded-t-md grid w-full min-h-100px overflow-hidden bg-(--iconset-color-bg) place-content-stretch " style="aspect-ratio: 5/{{ samples / 5 }};">
+    <div class="grid w-full min-h-100px overflow-hidden bg-(--iconset-color-bg) place-content-stretch " style="aspect-ratio: 5/{{ samples / 5 }};">
         <div class="max-h-full w-full rounded place-content-stretch grid grid-cols-5 items-stretch justify-stretch">
 
             {% for icon in sample_icons|default([]) %}

--- a/templates/components/LinkButton.html.twig
+++ b/templates/components/LinkButton.html.twig
@@ -1,12 +1,15 @@
 {% props url, label, outline = false, arrow = false %}
 
-{% set variant_classes = outline
-    ? 'border-body-text bg-transparent text-body-text opacity-85 hover:bg-body-text hover:text-body hover:opacity-100'
-    : 'border-body-text bg-body-text text-body opacity-85 hover:opacity-100'
-%}
-
 <a
     href="{{ url }}"
-    class="{{ ('inline-flex items-center justify-center gap-2 align-middle rounded-full border px-4 py-2 text-center transition-all duration-450 ease-out hover:duration-200 hover:scale-[1.02] ' ~ variant_classes ~ ' ' ~ attributes.render('class'))|tailwind_merge }}"
+    class="{{ html_cva(
+        base: 'inline-flex items-center justify-center gap-2 align-middle rounded-full border px-4 py-2 text-center transition-all duration-450 ease-out hover:duration-200 hover:scale-[1.02]',
+        variants: {
+            variant: {
+                outline: 'border-body-text bg-transparent text-body-text opacity-85 hover:bg-body-text hover:text-body hover:opacity-100',
+                solid: 'border-body-text bg-body-text text-body opacity-85 hover:opacity-100',
+            },
+        },
+    ).apply({variant: outline ? 'outline' : 'solid'}, attributes.render('class'))|tailwind_merge }}"
     {{ attributes.without('class') }}
 >{{ label }}{% if arrow %} <twig:ux:icon name="arrow-right" class="Icon -rotate-45" />{% endif %}</a>

--- a/templates/components/LinkButton.html.twig
+++ b/templates/components/LinkButton.html.twig
@@ -1,0 +1,12 @@
+{% props url, label, outline = false, arrow = false %}
+
+{% set variant_classes = outline
+    ? 'border-body-text bg-transparent text-body-text opacity-85 hover:bg-body-text hover:text-body hover:opacity-100'
+    : 'border-body-text bg-body-text text-body opacity-85 hover:opacity-100'
+%}
+
+<a
+    href="{{ url }}"
+    class="{{ ('inline-flex items-center justify-center gap-2 align-middle rounded-full border px-4 py-2 text-center transition-all duration-450 ease-out hover:duration-200 hover:scale-[1.02] ' ~ variant_classes ~ ' ' ~ attributes.render('class'))|tailwind_merge }}"
+    {{ attributes.without('class') }}
+>{{ label }}{% if arrow %} <twig:ux:icon name="arrow-right" class="Icon -rotate-45" />{% endif %}</a>

--- a/templates/components/LinkButton.html.twig
+++ b/templates/components/LinkButton.html.twig
@@ -1,15 +1,19 @@
 {% props url, label, outline = false, arrow = false %}
-
+{% set style = html_cva(
+    base: 'inline-flex items-center justify-center gap-2 align-middle rounded-full border px-4 py-2 text-center transition-all duration-450 ease-out hover:duration-200 hover:scale-[1.02]',
+    variants: {
+        variant: {
+            outline: 'border-body-text bg-transparent text-body-text opacity-85 hover:bg-body-text hover:text-body hover:opacity-100',
+            solid: 'border-body-text bg-body-text text-body opacity-85 hover:opacity-100',
+        },
+    },
+) %}
 <a
     href="{{ url }}"
-    class="{{ html_cva(
-        base: 'inline-flex items-center justify-center gap-2 align-middle rounded-full border px-4 py-2 text-center transition-all duration-450 ease-out hover:duration-200 hover:scale-[1.02]',
-        variants: {
-            variant: {
-                outline: 'border-body-text bg-transparent text-body-text opacity-85 hover:bg-body-text hover:text-body hover:opacity-100',
-                solid: 'border-body-text bg-body-text text-body opacity-85 hover:opacity-100',
-            },
-        },
-    ).apply({variant: outline ? 'outline' : 'solid'}, attributes.render('class'))|tailwind_merge }}"
-    {{ attributes.without('class') }}
->{{ label }}{% if arrow %} <twig:ux:icon name="arrow-right" class="Icon -rotate-45" />{% endif %}</a>
+    {{ attributes.defaults({
+        class: style.apply({variant: outline ? 'outline' : 'solid'})
+    }) }}
+>
+    {{- label -}}
+    {% if arrow %} <twig:ux:icon name="arrow-right" class="Icon -rotate-45" />{% endif -%}
+</a>

--- a/templates/components/Package/PackageBox.html.twig
+++ b/templates/components/Package/PackageBox.html.twig
@@ -1,6 +1,7 @@
 <twig:Box
     color="{{ package.color }}"
     gradient="{{ package.gradient }}"
+    radius="xl"
     titleTag="{{ titleTag }}"
 >
     <twig:block name="logo">

--- a/templates/components/Package/PackageHeader.html.twig
+++ b/templates/components/Package/PackageHeader.html.twig
@@ -2,7 +2,7 @@
     class="PackageHeader mb-12 {{ not (command ?? true) ? 'pb-12' }} pt-12"
     style="background: {{ package.gradient }}, {{ package.color }}; --color-accent: {{ package.color }};"
 >
-    <div class="max-w-[1400px] mx-auto px-6 pt-6 md:px-12 md:pt-12 position-relative">
+    <div class="max-w-[1400px] mx-auto px-6 pt-6 md:px-12 md:pt-12 relative">
 
         <p class="eyebrows text-center text-white mt-12 mb-4" style="opacity: 0.85;">{{ eyebrowText|raw }}</p>
 

--- a/templates/components/Package/PackageListItem.html.twig
+++ b/templates/components/Package/PackageListItem.html.twig
@@ -1,7 +1,7 @@
 {% set box_style = '--color: ' ~ package.color ~ '; --gradient: ' ~ (package.gradient ?: 'none') ~ '; --logo-size: 48px' %}
 
 <div
-    class="group relative flex gap-6 p-2 self-stretch border border-surface rounded-md bg-body"
+    class="group relative flex gap-6 p-2 self-stretch border border-surface rounded-lg bg-body"
     style="{{ box_style }}"
 >
     <div class="flex items-center justify-center shrink-0 rounded-[14%] [background-image:var(--gradient)] bg-(--color) w-(--logo-size) h-(--logo-size) [&_img]:w-[calc(0.4*var(--logo-size))] [&_img]:h-auto [&_img]:filter-[drop-shadow(4px_4px_4px_rgba(0,0,0,0))]">

--- a/templates/components/SupportBox.html.twig
+++ b/templates/components/SupportBox.html.twig
@@ -1,9 +1,9 @@
-<div class="body-bg border border-n-700 rounded-md flex flex-col gap-3 p-3 sm:gap-4 sm:p-4 relative place-self-stretch transition-transform duration-700 ease-in-out hover:duration-200 hover:-translate-y-1">
+<div class="bg-body border border-n-700 rounded-md flex flex-col gap-3 p-3 sm:gap-4 sm:p-4 relative place-self-stretch transition-transform duration-700 ease-in-out hover:duration-200 hover:-translate-y-1">
     <div class="size-8 sm:size-12 flex items-center justify-center shrink-0 [&>svg]:w-full [&>svg]:h-auto">
         {% block logo %}{% endblock %}
     </div>
     <div class="flex flex-col flex-1 gap-4">
-        <h2 class="font-medium text-2xs m-0">
+        <h2 class="font-medium text-sm m-0">
             {% block title %}{% endblock %}
         </h2>
         <p class="mb-0 leading-6">

--- a/templates/components/TerminalCommand.html.twig
+++ b/templates/components/TerminalCommand.html.twig
@@ -3,7 +3,7 @@
     data-clipboarder-source-value="{{ command }}"
 >
     <pre
-        class="z-4 m-0 px-2 w-[inherit] overflow-x-auto border-0 bg-transparent outline-none text-white text-[.9rem] font-monospace"
+        class="z-4 m-0 px-2 w-[inherit] overflow-x-auto border-0 bg-transparent outline-none text-white text-[.9rem] font-mono"
         aria-label="{{ label|default }}"
     ><code>{{ command }}</code></pre>
     <button

--- a/templates/demos/live_demo.html.twig
+++ b/templates/demos/live_demo.html.twig
@@ -71,7 +71,7 @@
         </div>
     {% endblock %}
 
-    <div class="max-w-[1140px] mx-auto x-4 pt-6 md:px-12 md:pt-12">
+    <div class="max-w-[1140px] mx-auto px-4 pt-6 md:px-12 md:pt-12">
         <div class="flex flex-wrap gap-6 justify-center items-center">
             <twig:Badge:Github label="Author" username="{{ demo.author }}" />
             <twig:Badge:Date label="Published" date="{{ demo.publishedAt }}" />

--- a/templates/icons/index.html.twig
+++ b/templates/icons/index.html.twig
@@ -48,10 +48,15 @@
         <p class="eyebrows" style="margin: 4rem 0 0;">Iconic Packages</p>
         <div class="md:flex md:justify-between text-center items-center md:text-start">
             <h2 class="ubuntu pt-2 component-headlines">Popular <em class="rainbow-emphasis">Icon Sets</em></h2>
-            <twig:Button href="https://symfony.com/bundles/ux-icons/current/index.html" rel="external" target="_blank" class="my-4 md:my-0">
-                Read Documentation
-                <twig:ux:icon name="arrow-right" class="Icon -rotate-45"/>
-            </twig:Button>
+            <twig:LinkButton
+                outline
+                label="Read documentation"
+                url="https://symfony.com/bundles/ux-icons/current/index.html"
+                arrow
+                rel="external"
+                target="_blank"
+                class="my-4 md:my-0"
+            />
         </div>
         <div class="mt-4 md:mt-12">
             <div style="display:grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 2rem;">
@@ -69,10 +74,15 @@
 
         <div class="md:flex md:justify-between py-12 text-center items-center md:text-start">
             <h2 class="ubuntu pt-2 component-headlines">Documentation</h2>
-            <twig:Button href="https://symfony.com/bundles/ux-icons/current/index.html" rel="external" target="_blank" class="my-4 md:my-0">
-                Read Full Documentation
-                <twig:ux:icon name="arrow-right" class="Icon -rotate-45"/>
-            </twig:Button>
+            <twig:LinkButton
+                outline
+                label="Read documentation"
+                url="https://symfony.com/bundles/ux-icons/current/index.html"
+                arrow
+                rel="external"
+                target="_blank"
+                class="my-4 md:my-0"
+            />
         </div>
 
         <div class="grid sm:grid-cols-3 gap-x-6 gap-y-3">

--- a/templates/main/homepage.html.twig
+++ b/templates/main/homepage.html.twig
@@ -48,10 +48,13 @@
     <p class="eyebrows" style="margin: 70px 0 0;">Stimulus Controllers</p>
     <div class="md:flex md:justify-between items-center text-center md:text-start">
         <h2 class="ubuntu pt-2 component-headlines">Write custom JavaScript inside <em class="rainbow-emphasis">Stimulus Controllers</em></h2>
-        <twig:Button href="https://symfony.com/doc/current/frontend/ux.html" class="my-4 md:my-0">
-            Read full Documentation
-            <twig:ux:icon name="arrow-right" class="Icon -rotate-45"/>
-        </twig:Button>
+        <twig:LinkButton
+            outline
+            label="Read documentation"
+            url="https://symfony.com/doc/current/frontend/ux.html"
+            arrow
+            class="my-4 md:my-0"
+        />
     </div>
 
     <div class="arrow mb-4 hidden md:block"></div>
@@ -102,10 +105,13 @@
     <p class="eyebrows" style="margin: 111px 0 0;">Packages</p>
     <div class="md:flex md:justify-between text-center items-center md:text-start">
         <h2 class="ubuntu pt-2 component-headlines">Install UX <em class="rainbow-emphasis">Components</em></h2>
-        <twig:Button href="{{ path('app_packages') }}" class="mt-4 md:mt-0">
-            Browse all Packages
-            <twig:ux:icon name="arrow-right" class="Icon -rotate-45"/>
-        </twig:Button>
+        <twig:LinkButton
+            outline
+            label="Browse all Packages"
+            url="{{ path('app_packages') }}"
+            arrow
+            class="mt-4 md:mt-0"
+        />
     </div>
     <div class="mt-4 md:mt-12">
         <div style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr));">

--- a/templates/ux_packages/_package_links.html.twig
+++ b/templates/ux_packages/_package_links.html.twig
@@ -1,11 +1,13 @@
 <aside class="bg-subtle mt-12">
     <div class="max-w-[1400px] mx-auto p-6 md:p-12">
         <div style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));">
-            {% if package.shouldShowDocsLink %}
+            {% set docs_url = docs_url|default(null) %}
+            {% set docs_text = docs_text|default('Symfony UX ' ~ package.humanName ~ ' Docs') %}
+            {% if package.shouldShowDocsLink or docs_url %}
                 <twig:DocsLink
                     title="Documentation"
-                    text="Symfony UX {{ package.humanName }} Docs"
-                    url="{{ package.officialDocsUrl }}"
+                    text="{{ docs_text }}"
+                    url="{{ docs_url|default(package.officialDocsUrl) }}"
                     icon="symfony"
                 />
             {% endif %}
@@ -33,7 +35,7 @@
                     title="Support"
                     text="Get help with Symfony UX {{ package.humanName }}"
                     url="{{ url('app_support') }}"
-                    icon="symfony"
+                    icon="raphael:help"
                 />
             {% endif %}
 

--- a/templates/ux_packages/live_component.html.twig
+++ b/templates/ux_packages/live_component.html.twig
@@ -45,10 +45,13 @@
     <h2 class="eyebrows mt-12" id="demos">Live Component Demos</h2>
     <div class="md:flex md:justify-between text-center items-center md:text-start">
         <h2 class="ubuntu pt-2 component-headlines">Find out what else you can <span style="color: #AE5929;">build</span></h2>
-        <twig:Button href="https://symfony.com/bundles/ux-live-component/current/index.html" class="my-4 md:my-0">
-            Read full Documentation
-            <twig:ux:icon name="arrow-right" class="Icon -rotate-45"/>
-        </twig:Button>
+        <twig:LinkButton
+            outline
+            label="Read documentation"
+            url="https://symfony.com/bundles/ux-live-component/current/index.html"
+            arrow
+            class="my-4 md:my-0"
+        />
     </div>
 
     <div class="mt-12 pb-12">

--- a/templates/ux_packages/toolkit.html.twig
+++ b/templates/ux_packages/toolkit.html.twig
@@ -14,7 +14,7 @@
         {% endblock %}
 
         {% block sub_content %}
-            With Toolkit comes “Kits”, a set of ready-to-use and fully-customizable UI Twig components and more, to help you to build your Design System.
+            With Toolkit, you get a flexible starting point for your Design System.
         {% endblock %}
 
         {% block header_actions %}
@@ -71,13 +71,19 @@ tree templates/components
 {% block package_install %}
     <div class="max-w-[1400px] mx-auto px-6 pt-6 md:px-12">
         <h2 class="ubuntu text-center mt-12" id="kits">Kits</h2>
-        <p class="text-center">
-            Kits are a set of ready-to-use and fully-customizable UI Twig components and more, to help you to build your Design System.<br>
+        <p class="text-center max-w-2xl mx-auto">
+            Pick a kit of reusable Twig components<br>
+            and start composing your interface.
         </p>
 
         <div class="mt-12 shadow-blur shadow-blur--rainbow" style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr)); --shadow-opacity: 0.2">
             {% for kit_id, kit in kits %}
-                <twig:Box color="{{ toolkit_color(kit_id) }}" titleTag="h2">
+                {% set kit_description = kit.manifest.description %}
+                {% if kit_id == 'flowbite-4' %}
+                    {% set kit_description = 'Components based on Flowbite (v4), a popular open-source UI library built with Tailwind CSS.' %}
+                {% endif %}
+
+                <twig:Box color="{{ toolkit_color(kit_id) }}" radius="xl" titleTag="h2">
                     <twig:block name="logo">
                         <twig:ux:icon name="toolkit:{{ kit_id }}" alt="{{ kit.manifest.name }}" style="color: #fff; width: 50%; height: 50%;" />
                     </twig:block>
@@ -85,12 +91,12 @@ tree templates/components
                         <a href="{{ path('app_toolkit_kit', {kitId: kit_id}) }}" class="stretched-link text-body-text no-underline">{{ kit.manifest.name }}</a>
                     </twig:block>
                     <twig:block name="description">
-                        <p>{{ kit.manifest.description }}</p>
+                        <p>{{ kit_description }}</p>
                     </twig:block>
                 </twig:Box>
             {% endfor %}
 
-            <twig:Box color="#24292f" titleTag="h2">
+            <twig:Box color="#24292f" radius="xl" titleTag="h2">
                 <twig:block name="badge">
                     <span class="absolute text-black bg-[#e9c502] [transform:rotate(-10deg)] py-[3px] px-2 top-[10px] left-0 text-xl font-bold z-10">
                         🚧 <abbr title="Work In Progress">WIP</abbr>!
@@ -113,4 +119,12 @@ tree templates/components
             </twig:Box>
         </div>
     </div>
+{% endblock %}
+
+{% block package_links %}
+    {{ include('ux_packages/_package_links.html.twig', {
+        package: package,
+        docs_url: url('app_toolkit'),
+        docs_text: 'Documentation for the Symfony UX Toolkit.',
+    }) }}
 {% endblock %}

--- a/templates/ux_packages/toolkit.html.twig
+++ b/templates/ux_packages/toolkit.html.twig
@@ -78,11 +78,6 @@ tree templates/components
 
         <div class="mt-12 shadow-blur shadow-blur--rainbow" style="display: grid; gap: 2rem; grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr)); --shadow-opacity: 0.2">
             {% for kit_id, kit in kits %}
-                {% set kit_description = kit.manifest.description %}
-                {% if kit_id == 'flowbite-4' %}
-                    {% set kit_description = 'Components based on Flowbite (v4), a popular open-source UI library built with Tailwind CSS.' %}
-                {% endif %}
-
                 <twig:Box color="{{ toolkit_color(kit_id) }}" radius="xl" titleTag="h2">
                     <twig:block name="logo">
                         <twig:ux:icon name="toolkit:{{ kit_id }}" alt="{{ kit.manifest.name }}" style="color: #fff; width: 50%; height: 50%;" />
@@ -91,7 +86,7 @@ tree templates/components
                         <a href="{{ path('app_toolkit_kit', {kitId: kit_id}) }}" class="stretched-link text-body-text no-underline">{{ kit.manifest.name }}</a>
                     </twig:block>
                     <twig:block name="description">
-                        <p>{{ kit_description }}</p>
+                        <p>{{ kit.manifest.description }}</p>
                     </twig:block>
                 </twig:Box>
             {% endfor %}

--- a/tests/Functional/UxPackagesTest.php
+++ b/tests/Functional/UxPackagesTest.php
@@ -49,7 +49,7 @@ class UxPackagesTest extends KernelTestCase
         foreach ($repository->findAll(removed: false) as $package) {
             if ('live-component' === $package->getName()) {
                 // Live Component has a different bottom section
-                yield $package->getName() => [$package, 'Read full Documentation'];
+                yield $package->getName() => [$package, 'Read documentation'];
                 continue;
             }
             if ('icons' === $package->getName()) {


### PR DESCRIPTION
| Q              | A
| -------------- | ---
| Issues         | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License        | MIT

This PR is a group of small visual, consistency, and usability improvements on Symfony UX website pages.

## Changes

- Fix invalid Tailwind utility classes
- Harmonize shared card radii, clipping, hover states, and shadows
- Add shared styling for tags and stretched links (cards are clickable again 🥳 )
- Add `LinkButton` component with `primary` and `outline` variants
- Use `LinkButton` for documentation and package navigation CTAs
- Make inline code backgrounds transparent in dark mode
- Polish Toolkit cards, copy, and documentation link
- Correct the Support icon
- Remove the outdated Bluesky `New` badge

